### PR TITLE
net: Refresh config dependency of NET_READAHEAD

### DIFF
--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -62,8 +62,8 @@ config IOB_NCHAINS
 		I/O buffer chain containers that also carry a payload of usage
 		specific information.
 
-		Note: TCP doesn't use this.
-		Note: UDP and CAN use this.
+		Note: TCP and UDP don't use this.
+		Note: ICMP/ICMPv6 and CAN use this.
 
 config IOB_THROTTLE
 	int "I/O buffer throttle value"

--- a/net/icmp/Kconfig
+++ b/net/icmp/Kconfig
@@ -37,7 +37,7 @@ config NET_ICMP_PMTU_TIMEOUT
 config NET_ICMP_SOCKET
 	bool "IPPROTO_ICMP socket support"
 	default n
-	select MM_IOB
+	select NET_READAHEAD
 	---help---
 		Enable support for IPPROTO_ICMP sockets.  These sockets are needed
 		for application level support for sending ECHO (ping) requests and

--- a/net/icmpv6/Kconfig
+++ b/net/icmpv6/Kconfig
@@ -39,7 +39,7 @@ config NET_ICMPv6_PMTU_TIMEOUT
 config NET_ICMPv6_SOCKET
 	bool "IPPROTO_ICMP6 socket support"
 	default n
-	select MM_IOB
+	select NET_READAHEAD
 	---help---
 		Enable support for IPPROTO_ICMP6 sockets.  These sockets are needed
 		for application level support for sending ICMPv7 ECHO requests and


### PR DESCRIPTION
## Summary

Refresh config dependency of `NET_READAHEAD`:
ICMP(v6) uses IOB queue as readahead, but TCP/UDP don't now.

## Impact

Kconfig dependency only.

## Testing

CI


