### PR TITLE
net: Move NET_TCP/UDP_HAVE_STACK to netconfig.h

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -64,6 +64,18 @@
  *                NET_SOCK_PROTOCOL);
  */
 
+/* The TCP/UDP stack, which is used for determining HAVE_PFINET(6)_SOCKETS */
+
+#undef NET_TCP_HAVE_STACK
+#if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
+#  define NET_TCP_HAVE_STACK 1
+#endif
+
+#undef NET_UDP_HAVE_STACK
+#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
+#  define NET_UDP_HAVE_STACK 1
+#endif
+
 /* The address family that we used to create the socket really does not
  * matter.  It should, however, be valid in the current configuration.
  */

--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -2,7 +2,8 @@
  * include/nuttx/net/netconfig.h
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2007, 2011, 2014-2015, 2017-2019 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2007, 2011, 2014-2015, 2017-2019 Gregory Nutt.
+ * All rights reserved.
  * SPDX-FileCopyrightText: 2001-2003, Adam Dunkels. All rights reserved.
  * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  * SPDX-FileContributor: Adam Dunkels <adam@dunkels.com>
@@ -67,9 +68,9 @@
  * matter.  It should, however, be valid in the current configuration.
  */
 
-#if defined(CONFIG_NET_IPv4)
+#if defined(HAVE_PFINET_SOCKETS)
 #  define NET_SOCK_FAMILY  AF_INET
-#elif defined(CONFIG_NET_IPv6)
+#elif defined(HAVE_PFINET6_SOCKETS)
 #  define NET_SOCK_FAMILY  AF_INET6
 #elif defined(CONFIG_NET_LOCAL)
 #  define NET_SOCK_FAMILY  AF_LOCAL

--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -68,6 +68,24 @@
  * matter.  It should, however, be valid in the current configuration.
  */
 
+#undef HAVE_INET_SOCKETS
+#undef HAVE_PFINET_SOCKETS
+#undef HAVE_PFINET6_SOCKETS
+
+#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
+#  define HAVE_INET_SOCKETS
+
+#  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
+#    define HAVE_PFINET_SOCKETS
+#  endif
+
+#  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
+#    define HAVE_PFINET6_SOCKETS
+#  endif
+#endif
+
 #if defined(HAVE_PFINET_SOCKETS)
 #  define NET_SOCK_FAMILY  AF_INET
 #elif defined(HAVE_PFINET6_SOCKETS)

--- a/libs/libc/net/lib_indextoname.c
+++ b/libs/libc/net/lib_indextoname.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <netinet/in.h>
 #include <nuttx/net/netconfig.h>
 
 /****************************************************************************

--- a/libs/libc/net/lib_nametoindex.c
+++ b/libs/libc/net/lib_nametoindex.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <netinet/in.h>
 #include <nuttx/net/netconfig.h>
 
 /****************************************************************************

--- a/net/inet/inet.h
+++ b/net/inet/inet.h
@@ -35,30 +35,6 @@
 #include <nuttx/net/ip.h>
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/* Configuration */
-
-#undef HAVE_INET_SOCKETS
-#undef HAVE_PFINET_SOCKETS
-#undef HAVE_PFINET6_SOCKETS
-
-#if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
-#  define HAVE_INET_SOCKETS
-
-#  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
-       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
-#    define HAVE_PFINET_SOCKETS
-#  endif
-
-#  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
-       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
-#    define HAVE_PFINET6_SOCKETS
-#  endif
-#endif
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 

--- a/net/inet/inet.h
+++ b/net/inet/inet.h
@@ -47,11 +47,13 @@
 #if defined(CONFIG_NET_IPv4) || defined(CONFIG_NET_IPv6)
 #  define HAVE_INET_SOCKETS
 
-#  if defined(CONFIG_NET_IPv4)
+#  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
 #    define HAVE_PFINET_SOCKETS
 #  endif
 
-#  if defined(CONFIG_NET_IPv6)
+#  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
+       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
 #    define HAVE_PFINET6_SOCKETS
 #  endif
 #endif

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -34,6 +34,7 @@
 #include <debug.h>
 
 #include <nuttx/net/net.h>
+#include <nuttx/net/netconfig.h>
 #include <nuttx/net/tcp.h>
 #include <nuttx/kmalloc.h>
 

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -122,7 +122,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
     }
   },
 #  endif
-#  if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
+#  ifdef NET_TCP_HAVE_STACK
   {
     DTYPE_FILE, "tcp",
     {
@@ -130,7 +130,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
     }
   },
 #  endif
-#  if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
+#  ifdef NET_UDP_HAVE_STACK
   {
     DTYPE_FILE, "udp",
     {

--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -188,4 +188,4 @@ ssize_t netprocfs_read_udpstats(FAR struct netprocfs_file_s *priv,
   return len;
 }
 
-#endif /* CONFIG_NET_UDP && !CONFIG_NET_UDP_NO_STACK */
+#endif /* NET_UDP_HAVE_STACK */

--- a/net/procfs/procfs.h
+++ b/net/procfs/procfs.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 #include <sys/types.h>
 #include <nuttx/fs/procfs.h>
+#include <nuttx/net/netconfig.h>
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_NET)
 
@@ -184,7 +185,7 @@ ssize_t netprocfs_read_mldstats(FAR struct netprocfs_file_s *priv,
  *
  ****************************************************************************/
 
-#if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
+#ifdef NET_TCP_HAVE_STACK
 ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
                                 FAR char *buffer, size_t buflen);
 #endif
@@ -207,7 +208,7 @@ ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
  *
  ****************************************************************************/
 
-#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
+#ifdef NET_UDP_HAVE_STACK
 ssize_t netprocfs_read_udpstats(FAR struct netprocfs_file_s *priv,
                                 FAR char *buffer, size_t buflen);
 #endif

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/net/net.h>
+#include <nuttx/net/netconfig.h>
 
 #include "inet/inet.h"
 #include "local/local.h"

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -76,7 +76,7 @@ net_sockif(sa_family_t family, int type, int protocol)
 
   switch (family)
     {
-#ifdef HAVE_INET_SOCKETS
+#if defined(HAVE_PFINET_SOCKETS) || defined(HAVE_PFINET6_SOCKETS)
 #  ifdef HAVE_PFINET_SOCKETS
     case PF_INET:
 #  endif

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -40,7 +40,7 @@
 #include <nuttx/net/tcp.h>
 #include <nuttx/wqueue.h>
 
-#ifdef CONFIG_NET_TCP
+#ifdef NET_TCP_HAVE_STACK
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -50,10 +50,6 @@
 
 #define TCPIPv4BUF ((FAR struct tcp_hdr_s *)IPBUF(IPv4_HDRLEN))
 #define TCPIPv6BUF ((FAR struct tcp_hdr_s *)IPBUF(IPv6_HDRLEN))
-
-#ifndef CONFIG_NET_TCP_NO_STACK
-
-#define NET_TCP_HAVE_STACK 1
 
 /* Allocate a new TCP data callback */
 
@@ -2354,6 +2350,5 @@ void tcp_cc_recv_ack(FAR struct tcp_conn_s *conn, FAR struct tcp_hdr_s *tcp);
 
 void tcp_set_zero_probe(FAR struct tcp_conn_s *conn, uint16_t flags);
 
-#endif /* !CONFIG_NET_TCP_NO_STACK */
-#endif /* CONFIG_NET_TCP */
+#endif /* NET_TCP_HAVE_STACK */
 #endif /* __NET_TCP_TCP_H */

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -43,13 +43,11 @@
 #  include <nuttx/wqueue.h>
 #endif
 
-#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
+#ifdef NET_UDP_HAVE_STACK
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#define NET_UDP_HAVE_STACK 1
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
 /* UDP write buffer dump macros */
@@ -1046,5 +1044,5 @@ uint16_t udpip_hdrsize(FAR struct udp_conn_s *conn);
 }
 #endif
 
-#endif /* CONFIG_NET_UDP && !CONFIG_NET_UDP_NO_STACK */
+#endif /* NET_UDP_HAVE_STACK */
 #endif /* __NET_UDP_UDP_H */


### PR DESCRIPTION
## Summary

Now the `HAVE_PFINET(6)_SOCKETS` depends on `NET_TCP/UDP_HAVE_STACK`, which is previously defined in `net/` folder and cannot be included. Considering many places use this check, maybe moving them to `netconfig.h` could be better.

## Impact

Before: IPv4 + TCP, without ICMP -> `HAVE_PFINET_SOCKETS` is undefined, we cannot use TCP socket (error is `EAFNOSUPPORT`)
After: IPv4 + TCP, without ICMP -> `HAVE_PFINET_SOCKETS` is defined, we can use TCP socket

## Testing

QEMU with `CONFIG_NET_IPv4` & `CONFIG_NET_TCP` enabled but `CONFIG_NET_ICMP_SOCKET` disabled.