### PR TITLE
netinet/if_ether.h: move #define ETH_XXX into if_ether.h

### DIFF
--- a/include/netinet/if_ether.h
+++ b/include/netinet/if_ether.h
@@ -35,7 +35,16 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ETH_ALEN  6    /* Octets in one ethernet addr   */
+#define ETH_ALEN  6         /* Octets in one ethernet addr   */
+#define ETH_TLEN  2         /* Octets in ethernet type field */
+#define ETH_HLEN  14        /* Total octets in header.   */
+#define ETH_ZLEN  60        /* Min. octets in frame sans FCS */
+#define ETH_DATA_LEN  1500  /* Max. octets in payload  */
+#define ETH_FRAME_LEN 1514  /* Max. octets in frame sans FCS */
+#define ETH_FCS_LEN 4       /* Octets in the FCS     */
+
+#define ETH_MIN_MTU 68      /* Min IPv4 MTU per RFC791  */
+#define ETH_MAX_MTU 0xFFFFU /* 65535, same as IP_MAX_MTU  */
 
 #define ETH_P_IP  ETHERTYPE_IP
 #define ETH_P_ARP ETHERTYPE_ARP

--- a/include/nuttx/wireless/ieee80211/ieee80211.h
+++ b/include/nuttx/wireless/ieee80211/ieee80211.h
@@ -39,24 +39,11 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 
+#include <netinet/if_ether.h>
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-/*  IEEE 802.3 Ethernet magic constants.  The frame sizes omit the preamble
- *  and FCS/CRC (frame check sequence).
- */
-
-#define ETH_ALEN  6         /* Octets in one ethernet addr   */
-#define ETH_TLEN  2         /* Octets in ethernet type field */
-#define ETH_HLEN  14        /* Total octets in header.   */
-#define ETH_ZLEN  60        /* Min. octets in frame sans FCS */
-#define ETH_DATA_LEN  1500  /* Max. octets in payload  */
-#define ETH_FRAME_LEN 1514  /* Max. octets in frame sans FCS */
-#define ETH_FCS_LEN 4       /* Octets in the FCS     */
-
-#define ETH_MIN_MTU 68      /* Min IPv4 MTU per RFC791  */
-#define ETH_MAX_MTU 0xFFFFU /* 65535, same as IP_MAX_MTU  */
 
 /* DS bit usage
  *


### PR DESCRIPTION
### Summary
Move ETH_XXX related definitions to a more appropriate header file.

### Impact
None.

### Testing
Mainly on SIM.