### PR TITLE
tcp: fix tcp can not retransmit timely when ACK with TCP_NEWDATA

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -594,18 +594,26 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_TCP_CC_NEWRENO
               if (conn->dupacks >= TCP_FAST_RETRANSMISSION_THRESH)
 #else
-              /* Reset the duplicate ack counter */
-
-              if ((flags & TCP_NEWDATA) != 0)
-                {
-                  TCP_WBNACK(wrb) = 0;
-                }
-
               /* Duplicate ACK? Retransmit data if need */
 
               if (++TCP_WBNACK(wrb) == TCP_FAST_RETRANSMISSION_THRESH)
 #endif
                 {
+                  /* Fast retransmission has been triggered */
+
+                  if ((flags & TCP_NEWDATA) != 0)
+                    {
+                      /* The current receive data needs to be handled by
+                       * following tcp_recvhandler or tcp_data_event. Notify
+                       * driver to send the message and marked as rexmit
+                       */
+
+                      TCP_WBNACK(wrb) = 0;
+                      conn->timeout = true;
+                      netdev_txnotify_dev(conn->dev);
+                      return flags;
+                    }
+
 #ifdef CONFIG_NET_TCP_SELECTIVE_ACK
                   if ((conn->flags & TCP_SACK) &&
                       (tcp->tcpoffset & 0xf0) > 0x50)


### PR DESCRIPTION
### Summary
If the TCP_ACK carrying the data triggers a retransmission, the retransmission needs to wait for the next TCP_POLL.
The current receive data needs to be handled by following tcp_recvhandler or tcp_data_event. so we just notify driver to send the message and marked as `rexmit` in `psock_send_eventhandler`.

### Testing
Mainly on SIM and Cortex-M33 board.