### PR TITLE
cmake(bugfix):fix directory not being successfully added when adding romfs

### DIFF
--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -82,8 +82,8 @@ function(nuttx_add_romfs)
       board_rcraws
       TARGET board
       PROPERTY BOARD_RCRAWS)
-    list(APPEND RCSRCS ${board_rcsrcs})
-    list(APPEND RCRAWS ${board_rcraws})
+    list(PREPEND RCSRCS ${board_rcsrcs})
+    list(PREPEND RCRAWS ${board_rcraws})
   endif()
 
   foreach(rcsrc ${RCSRCS})
@@ -120,16 +120,15 @@ function(nuttx_add_romfs)
     endif()
 
     if(IS_DIRECTORY ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
-      file(
-        GLOB subraws
-        LIST_DIRECTORIES false
-        RELATIVE ${SOURCE_ETC_PREFIX}
-        ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
-      foreach(subraw ${subraws})
-        list(APPEND DEPENDS ${SOURCE_ETC_PREFIX}/${subraw})
-        configure_file(${SOURCE_ETC_PREFIX}/${subraw}
-                       ${CMAKE_CURRENT_BINARY_DIR}/${subraw} COPYONLY)
-      endforeach()
+      add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX}
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+                ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX}
+        COMMAND
+          ${CMAKE_COMMAND} -E copy_directory
+          ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX}
+          ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX})
+      list(APPEND DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX})
     else()
       list(APPEND DEPENDS ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
       configure_file(${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX}


### PR DESCRIPTION
## Summary

This patch solves two problems of adding romfs raw directory: 

1. refactored the directory adding logic to fix the problem that the directory could not be added
2. board content should overwrite common content

## Impact

bugfix

## Testing

cmake -B build -DBOARD_CONFIG=sim:nsh
build pass 
