### PR TITLE
cmake(enhance):add NuttX CMake extensions module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,9 @@ include(menuconfig)
 include(ExternalProject)
 include(FetchContent)
 
+# add NuttX CMake extenstion at last
+include(nuttx_extensions)
+
 set(FETCHCONTENT_QUIET OFF)
 
 # Board common directory #####################################################

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -95,9 +95,13 @@ function(nuttx_add_application)
     ARGN
     ${ARGN})
 
+  # check if SRCS exist
+  if(SRCS)
+    file(GLOB SRCS_EXIST ${SRCS})
+  endif()
   # create target
 
-  if(SRCS)
+  if(SRCS_EXIST)
     if(MODULE
        AND ("${MODULE}" STREQUAL "m")
        OR CONFIG_BUILD_KERNEL)
@@ -169,6 +173,8 @@ function(nuttx_add_application)
     set(TARGET "apps_${NAME}")
     add_custom_target(${TARGET})
     set_property(GLOBAL APPEND PROPERTY NUTTX_APPS_ONLY_REGISTER ${TARGET})
+    set_target_properties(${TARGET} PROPERTIES NO_COMPILABLE_TARGET True)
+    set(NO_COMPILABLE_TARGET True)
   endif()
 
   # apps applications need to depends on apps_context by default
@@ -194,22 +200,25 @@ function(nuttx_add_application)
                                                ${CONFIG_DEFAULT_TASK_STACKSIZE})
   endif()
 
-  # compile options
+  # call target_ options only target is compilable
+  if(NOT NO_COMPILABLE_TARGET)
+    # compile options
 
-  if(COMPILE_FLAGS)
-    target_compile_options(${TARGET} PRIVATE ${COMPILE_FLAGS})
-  endif()
+    if(COMPILE_FLAGS)
+      target_compile_options(${TARGET} PRIVATE ${COMPILE_FLAGS})
+    endif()
 
-  # compile definitions
+    # compile definitions
 
-  if(DEFINITIONS)
-    target_compile_definitions(${TARGET} PRIVATE ${DEFINITIONS})
-  endif()
+    if(DEFINITIONS)
+      target_compile_definitions(${TARGET} PRIVATE ${DEFINITIONS})
+    endif()
 
-  if(INCLUDE_DIRECTORIES)
-    foreach(inc ${INCLUDE_DIRECTORIES})
-      target_include_directories(${TARGET} PRIVATE ${inc})
-    endforeach()
+    if(INCLUDE_DIRECTORIES)
+      foreach(inc ${INCLUDE_DIRECTORIES})
+        target_include_directories(${TARGET} PRIVATE ${inc})
+      endforeach()
+    endif()
   endif()
 
   # add supplied dependencies

--- a/cmake/nuttx_add_dependencies.cmake
+++ b/cmake/nuttx_add_dependencies.cmake
@@ -55,6 +55,11 @@ function(nuttx_add_dependencies)
     ARGN
     ${ARGN})
 
+  get_target_property(NO_COMPILABLE_TARGET ${TARGET} NO_COMPILABLE_TARGET)
+  if(NO_COMPILABLE_TARGET)
+    return()
+  endif()
+
   foreach(dep ${DEPENDS})
     # add dependencies
     add_dependencies(${TARGET} ${dep})

--- a/cmake/nuttx_extensions.cmake
+++ b/cmake/nuttx_extensions.cmake
@@ -1,0 +1,224 @@
+# ##############################################################################
+# cmake/nuttx_extensions.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# This is NuttX's enhancement of various native CMake operations.
+
+include(nuttx_parse_function_args)
+
+# Macro: nuttx_library
+#
+# Creates a library target with the given name and mode. If MODE is "KERNEL", it
+# calls nuttx_add_kernel_library instead.
+#
+# Usage: nuttx_library(mylib) nuttx_library(mylib MODE "KERNEL")
+macro(nuttx_library name)
+  cmake_parse_arguments(ARGS "" MODE "" ${ARGN})
+
+  set(NX_CURRENT_LIBRARY ${name})
+
+  if(NOT ARGS_MODE)
+    nuttx_add_library(${name} STATIC)
+  elseif("${ARGS_MODE}" STREQUAL "KERNEL")
+    nuttx_add_kernel_library(${name})
+  endif()
+endmacro()
+
+# Macro: nuttx_library_ifdef
+#
+# Conditionally creates a library target if the given condition is true.
+#
+# Usage: nuttx_library_ifdef(MY_CONDITION mylib)
+macro(nuttx_library_ifdef cond name)
+  if(${cond})
+    nuttx_library(${name} ${ARGN})
+  endif()
+endmacro()
+
+# Macro: nuttx_library_ifndef
+#
+# Conditionally creates a library target if the given condition is false.
+#
+# Usage: nuttx_library_ifndef(MY_CONDITION mylib)
+macro(nuttx_library_ifndef cond name)
+  if(NOT ${cond})
+    nuttx_library(${name} ${ARGN})
+  endif()
+endmacro()
+
+# Function: nuttx_sources
+#
+# Adds source files to the current library target.
+#
+# Usage: nuttx_sources(source1.cpp source2.cpp)
+function(nuttx_sources)
+  if(TARGET ${NX_CURRENT_LIBRARY})
+    target_sources(${NX_CURRENT_LIBRARY} PRIVATE ${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_sources_ifdef
+#
+# Conditionally adds source files to the current library target if the given
+# condition is true.
+#
+# Usage: nuttx_sources_ifdef(MY_CONDITION source1.cpp source2.cpp)
+function(nuttx_sources_ifdef cond)
+  if(${cond})
+    nuttx_sources(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_sources_ifndef
+#
+# Conditionally adds source files to the current library target if the given
+# condition is false.
+#
+# Usage: nuttx_sources_ifndef(MY_CONDITION source1.cpp source2.cpp)
+function(nuttx_sources_ifndef cond)
+  if(NOT ${cond})
+    nuttx_sources(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_wildcard_sources
+#
+# Adds source files matching a wildcard pattern to the current library target,
+# excluding those matching the exclude pattern.
+#
+# Usage: nuttx_wildcard_sources("*.c" EXCLUDE "exclude_me.c")
+function(nuttx_wildcard_sources)
+  cmake_parse_arguments(ARGS "" "" EXCLUDE ${ARGN})
+
+  file(GLOB SRCS ${ARGN})
+  if(ARGS_EXCLUDE)
+    file(GLOB RM_SRCS ${ARGS_EXCLUDE})
+    list(REMOVE_ITEM SRCS ${RM_SRCS})
+  endif()
+  nuttx_sources(${SRCS})
+endfunction()
+
+# Function: nuttx_include_directories
+#
+# Adds include directories to the current library target.
+#
+# Usage: nuttx_include_directories("include/path1" "include/path2")
+function(nuttx_include_directories)
+  if(TARGET ${NX_CURRENT_LIBRARY})
+    target_include_directories(${NX_CURRENT_LIBRARY} PRIVATE ${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_include_directories_ifdef
+#
+# Conditionally adds include directories to the current library target if the
+# given condition is true.
+#
+# Usage: nuttx_include_directories_ifdef(MY_CONDITION "include/path1"
+# "include/path2")
+function(nuttx_include_directories_ifdef cond)
+  if(${cond})
+    nuttx_include_directories(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_include_directories_ifndef
+#
+# Conditionally adds include directories to the current library target if the
+# given condition is false.
+#
+# Usage: nuttx_include_directories_ifndef(MY_CONDITION "include/path1"
+# "include/path2")
+function(nuttx_include_directories_ifndef cond)
+  if(NOT ${cond})
+    nuttx_include_directories(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_compile_definitions
+#
+# Adds compile definitions to the current library target.
+#
+# Usage: nuttx_compile_definitions("DEF1" "DEF2")
+function(nuttx_compile_definitions)
+  if(TARGET ${NX_CURRENT_LIBRARY})
+    target_compile_definitions(${NX_CURRENT_LIBRARY} PRIVATE ${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_compile_definitions_ifdef
+#
+# Conditionally adds compile definitions to the current library target if the
+# given condition is true.
+#
+# Usage: nuttx_compile_definitions_ifdef(MY_CONDITION "DEF1" "DEF2")
+function(nuttx_compile_definitions_ifdef cond)
+  if(${cond})
+    nuttx_compile_definitions(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_compile_definitions_ifndef
+#
+# Conditionally adds compile definitions to the current library target if the
+# given condition is false.
+#
+# Usage: nuttx_compile_definitions_ifndef(MY_CONDITION "DEF1" "DEF2")
+function(nuttx_compile_definitions_ifndef cond)
+  if(NOT ${cond})
+    nuttx_compile_definitions(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_compile_options
+#
+# Adds compile options to the current library target.
+#
+# Usage: nuttx_compile_options("-O2" "-Wall")
+function(nuttx_compile_options)
+  if(TARGET ${NX_CURRENT_LIBRARY})
+    target_compile_options(${NX_CURRENT_LIBRARY} PRIVATE ${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_compile_options_ifdef
+#
+# Conditionally adds compile options to the current library target if the given
+# condition is true.
+#
+# Usage: nuttx_compile_options_ifdef(MY_CONDITION "-O2" "-Wall")
+function(nuttx_compile_options_ifdef cond)
+  if(${cond})
+    nuttx_compile_options(${ARGN})
+  endif()
+endfunction()
+
+# Function: nuttx_compile_options_ifndef
+#
+# Conditionally adds compile options to the current library target if the given
+# condition is false.
+#
+# Usage: nuttx_compile_options_ifndef(MY_CONDITION "-O2" "-Wall")
+function(nuttx_compile_options_ifndef cond)
+  if(NOT ${cond})
+    nuttx_compile_options(${ARGN})
+  endif()
+endfunction()


### PR DESCRIPTION
## Summary

[Enhancement]

1. Wrapped CMake native method is nuttx_cmake module,
It can be quickly called in the build system

2. Add sanity check for commonly called functions

**This will make our build system simpler and more modern :-)**

e.g:
```cmake
# we are currently adding an application library like:
# apps/libfoo/CMakeLists.txt
if(CONFIG_LIB_FOO)
  set(FLAGS -Werror)
  set(INCDIR ${CMAKE_CURRENT_LIST_DIR}/include)

  file(GLOB CSRCS ${CMAKE_CURRENT_LIST_DIR}/*.c)
  set(CSRCS ${CSRCS})

  if(CONFIG_AAA)
    list(APPEND CSRCS a.c)
  endif()
 
  if(CONFIG_BBB)
    list(APPEND CSRCS b.c)
  endif()

  if(CONFIG_OPT)
    list(APPEND FLAGS -Os)
  endif()
  
  nuttx_add_library(foo STATIC)
  target_sources(foo PRIVATE ${CSRCS})
  target_compile_options(foo PRIVATE ${FLAGS})
  target_include_directories(foo PRIVATE ${INCDIR})

endif()

``` 
```python
# after using the extension, it can be simplified to:
# apps/libfoo/CMakeLists.txt
nuttx_library_ifdef(CONFIG_LIB_FOO foo)

nuttx_wildcard_sources(./*.c)
nuttx_sources_ifdef(CONFIG_AAA a.c)
nuttx_sources_ifdef(CONFIG_BBB b.c)

nuttx_compile_options(-Werror)
nuttx_compile_options_ifdef(CONFIG_OPT -Os)

nuttx_include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
``` 

## Impact

Enhanced cmake module, forward compatibility, no impact on the past

## Testing

I haven't made any module changes to use the new extensions, 
but I've modified the tests in local apps and it's feasible. 
It greatly reduces the amount of code and is elegant enough.