### PR TITLE
cmake[bugfix]:fix CMake build of xtensa arch platform lib missing

### DIFF
--- a/arch/xtensa/src/cmake/platform.cmake
+++ b/arch/xtensa/src/cmake/platform.cmake
@@ -65,5 +65,20 @@ if(CONFIG_SCHED_GCOV)
   list(APPEND EXTRA_LIB ${extra_library})
 endif()
 
-nuttx_add_extra_library(${EXTRA_LIB})
+if(CONFIG_XTENSA_TOOLCHAIN_XCLANG)
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAG_ARGS} ${NUTTX_EXTRA_FLAGS}
+            --show-config=config
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE xt_path)
+
+  foreach(lib ${EXTRA_LIB})
+    file(GLOB_RECURSE find_lib ${xt_path}/xtensa-elf/lib/${lib}
+         ${xt_path}/xtensa-elf/lib/*/${lib})
+    nuttx_add_extra_library(${find_lib})
+  endforeach()
+else()
+  nuttx_add_extra_library(${EXTRA_LIB})
+endif()
+
 set(PREPROCESS ${CMAKE_PREPROCESSOR})


### PR DESCRIPTION
【Bugfix】
fix CMake build of xtensa arch platform lib missing