### PR TITLE
cmake(feat):add default install prefix path to ${BINARY}/staging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# default install path is from the original Makefile staging.
+set(CMAKE_INSTALL_PREFIX
+    ${CMAKE_BINARY_DIR}/staging
+    CACHE PATH "Global install prefix" FORCE)
+
 # Setup build type (Debug Release RelWithDebInfo MinSizeRel Coverage). Default
 # to minimum size release
 


### PR DESCRIPTION

When `--install prefix `is ​​not specified, 
the default static library installation address is set to ${BINARY}/staging