### PR TITLE
fs/vfs: Fix initialization of `g_pseudofile_ops`

### DIFF
--- a/fs/vfs/fs_pseudofile.c
+++ b/fs/vfs/fs_pseudofile.c
@@ -95,6 +95,8 @@ static const struct file_operations g_pseudofile_ops =
   pseudofile_mmap,     /* mmap */
   pseudofile_truncate, /* truncate */
   NULL,                /* poll */
+  NULL,                /* readv */
+  NULL,                /* writev */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   pseudofile_unlink,   /* unlink */
 #endif


### PR DESCRIPTION
## Summary
fs/vfs: Fix initialization of `g_pseudofile_ops`

- Config: sim:nsh with PIPES enabled.
- Log
```
  CC:  driver/fs_registerblockdriver.c vfs/fs_pseudofile.c:99:3: warning: initialization of ‘ssize_t (*)(struct file *, const struct uio *)’ {aka ‘long int (*)(struct file *, const struct uio *)’} from incompatible pointer type ‘int (*)(struct inode *)’ [-Wincompatible-pointer-types]
      99 |   pseudofile_unlink,   /* unlink */
         |   ^~~~~~~~~~~~~~~~~
  vfs/fs_pseudofile.c:99:3: note: (near initialization for ‘g_pseudofile_ops.readv’)
```

Related: https://github.com/apache/nuttx/pull/13498
## Impact
fs/vfs/fs_pseudofile.c

## Testing
1. Selftest: sim:nsh
2. CI


