### PR TITLE
cmake(bugfix):do not set nuttx_add_app NAME as required

### DIFF
--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -90,10 +90,12 @@ function(nuttx_add_application)
     DEFINITIONS
     OPTIONS
     NO_MAIN_ALIAS
-    REQUIRED
-    NAME
     ARGN
     ${ARGN})
+
+  if(NOT NAME)
+    return()
+  endif()
 
   # check if SRCS exist
   if(SRCS)


### PR DESCRIPTION
## Summary

do not set nuttx_add_app NAME as required

    Instead, use direct return, because in non-build targets,
    such as savedefconfig, menuconfig, this check is unnecessary

## Impact

bugfix

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela --cmake 

```


