### PR TITLE
fs/procfs: The procfsversion should be under control of `FS_PROCFS_EXCLUDE_VERSION`

### DIFF
--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -48,7 +48,7 @@
 #include "fs_heap.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS)
-#ifndef CONFIG_FS_PROCFS_EXCLUDE_PROCESS
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_VERSION
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
The procfsversion should be under control of `FS_PROCFS_EXCLUDE_VERSION`

#### Env
```diff
#sim:nsh
- CONFIG_FS_PROCFS_EXCLUDE_PROCESS=y
```
#### Link error
```
LD:  nuttx
/usr/bin/ld: nuttx.rel:(.rodata.g_procfs_entries+0xc8): undefined reference to `g_version_operations'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:429: nuttx] Error 1
make: *** [tools/Unix.mk:551: nuttx] Error 2
```
## Impact
fs/procfs

## Testing
1. Selftest: Using `sim:nsh` with `CONFIG_FS_PROCFS_EXCLUDE_PROCESS` disabled
2. CI