### PR TITLE
cmake(enhance):enhance NuttX cmake target dependencies and link_library modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,10 @@ nuttx_export_kconfig(${CMAKE_BINARY_DIR}/.config)
 include(nuttx_generate_headers)
 include(nuttx_generate_outputs)
 include(nuttx_add_library)
+
+# add NuttX CMake extenstion after nuttx_add_library
+include(nuttx_extensions)
+
 include(nuttx_add_application)
 include(nuttx_add_romfs)
 include(nuttx_add_symtab)
@@ -376,9 +380,6 @@ include(menuconfig)
 
 include(ExternalProject)
 include(FetchContent)
-
-# add NuttX CMake extenstion at last
-include(nuttx_extensions)
 
 set(FETCHCONTENT_QUIET OFF)
 
@@ -580,6 +581,9 @@ if(NOT CONFIG_BUILD_KERNEL)
   endif()
 
 endif()
+
+# after we traverse all build directories unify all target dependencies
+process_all_target_dependencies()
 
 # Link step ##################################################################
 

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -154,6 +154,24 @@ function(nuttx_add_application)
       set(TARGET "apps_${NAME}")
       add_library(${TARGET} ${SRCS})
 
+      # Set apps global compile options & definitions hold by
+      # nuttx_apps_interface
+      target_compile_options(
+        ${TARGET}
+        PRIVATE
+          $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_OPTIONS>>
+      )
+      target_compile_definitions(
+        ${TARGET}
+        PRIVATE
+          $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_DEFINITIONS>>
+      )
+      target_include_directories(
+        ${TARGET}
+        PRIVATE
+          $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_INCLUDE_DIRECTORIES>>
+      )
+
       nuttx_add_library_internal(${TARGET})
       # add to list of application libraries
 

--- a/cmake/nuttx_add_dependencies.cmake
+++ b/cmake/nuttx_add_dependencies.cmake
@@ -20,6 +20,9 @@
 #
 # ##############################################################################
 
+# global dependency maintenance target
+add_custom_target(nuttx_dep_map)
+
 include(nuttx_parse_function_args)
 
 # ~~~
@@ -55,16 +58,47 @@ function(nuttx_add_dependencies)
     ARGN
     ${ARGN})
 
-  get_target_property(NO_COMPILABLE_TARGET ${TARGET} NO_COMPILABLE_TARGET)
-  if(NO_COMPILABLE_TARGET)
-    return()
-  endif()
+  set_property(
+    TARGET nuttx_dep_map
+    APPEND
+    PROPERTY ALL_PROCESS_TARGET ${TARGET})
 
   foreach(dep ${DEPENDS})
-    # add dependencies
-    add_dependencies(${TARGET} ${dep})
-    # add export include directory
-    target_include_directories(${TARGET}
-                               PRIVATE ${NUTTX_APPS_BINDIR}/include/${dep})
+    set_property(
+      TARGET nuttx_dep_map
+      APPEND
+      PROPERTY ${TARGET} ${dep})
+  endforeach()
+endfunction()
+
+# After collecting all dependency mappings, process all targets uniformly
+function(process_all_target_dependencies)
+  # get all target need add deps
+  get_property(
+    all_process_target
+    TARGET nuttx_dep_map
+    PROPERTY ALL_PROCESS_TARGET)
+  foreach(target ${all_process_target})
+    if(TARGET ${target})
+      get_target_property(NO_COMPILABLE_TARGET ${target} NO_COMPILABLE_TARGET)
+      if(NOT NO_COMPILABLE_TARGET)
+        # treat `target` as mapping key
+        get_property(
+          all_deps
+          TARGET nuttx_dep_map
+          PROPERTY ${target})
+        foreach(dep ${all_deps})
+          if(TARGET ${dep})
+            # ensure build time order
+            add_dependencies(${target} ${dep})
+            # inherit public properties
+            nuttx_link_libraries(${target} ${dep})
+            # compatible with previous export headers
+            target_include_directories(
+              ${target} PRIVATE ${NUTTX_APPS_BINDIR}/include/${dep})
+          endif()
+        endforeach()
+      endif()
+    endif()
   endforeach()
 endfunction()

--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -183,7 +183,22 @@ function(nuttx_add_library target)
   add_library(${target} ${ARGN})
   add_dependencies(${target} apps_context)
   set_property(GLOBAL APPEND PROPERTY NUTTX_SYSTEM_LIBRARIES ${target})
-
+  # Set apps global compile options & definitions hold by nuttx_apps_interface
+  target_compile_options(
+    ${target}
+    PRIVATE
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_OPTIONS>>
+  )
+  target_compile_definitions(
+    ${target}
+    PRIVATE
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_COMPILE_DEFINITIONS>>
+  )
+  target_include_directories(
+    ${target}
+    PRIVATE
+      $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_apps_interface,APPS_INCLUDE_DIRECTORIES>>
+  )
   nuttx_add_library_internal(${target})
 endfunction()
 


### PR DESCRIPTION
## Summary

enhance NuttX cmake target dependencies and link_library modules

Enhance CMake's add_dependencies for Nuttx so that different targets can call dependencies without errors when they are not traversed.

In addition, since we do not call link_library directly, we increment nuttx_link_library to inherit the PUBLIC property

## Impact

new feat

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela --cmake 

```


