### PR TITLE
drivers/bch: Drivers may not support command `BIOC_FLUSH`

### DIFF
--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -455,6 +455,13 @@ static int bch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           if (bchinode->u.i_bops->ioctl != NULL)
             {
               ret = bchinode->u.i_bops->ioctl(bchinode, cmd, arg);
+
+              /* Drivers may not support command BIOC_FLUSH */
+
+              if (ret == -ENOTTY && cmd == BIOC_FLUSH)
+                {
+                  ret = 0;
+                }
             }
         }
         break;


### PR DESCRIPTION
## Summary
drivers/bch: Drivers may not support command `BIOC_FLUSH`.
Calling `bchlib_flushsector()` maybe enough on some devices.

## Impact
- drivers/bch (e.g. `fsync()` on bch device may returns failure without this patch)

## Testing
- Selftest with `fsync()`
- NuttX CI


