### PR TITLE
net: Sync changes in tcp_pollsetup

### DIFF
--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -230,7 +230,6 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   info = conn->pollinfo;
   while (info->conn != NULL)
     {
-      DEBUGASSERT((fds->events & info->fds->events) != 0);
       if (++info >= &conn->pollinfo[CONFIG_NET_TCP_NPOLLWAITERS])
         {
           DEBUGPANIC();

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -230,12 +230,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   info = conn->pollinfo;
   while (info->conn != NULL)
     {
-      if ((fds->events & info->fds->events) != 0)
-        {
-          nwarn("WARNING: fds->events %" PRIx32 " same event bit\n",
-                fds->events);
-        }
-
+      DEBUGASSERT((fds->events & info->fds->events) != 0);
       if (++info >= &conn->pollinfo[CONFIG_NET_TCP_NPOLLWAITERS])
         {
           DEBUGPANIC();


### PR DESCRIPTION
Patches included:
- tcp:set NET_TCP_NPOLLWAITERS default value to 2 & add warning of different events having same event bit
- net: Remove the DEBUGASSERT of the same event of the same fd in tcp_pollsetup