### PR TITLE
coredump relative change, block/mtd stream support update

### DIFF
--- a/arch/renesas/src/rx65n/Kconfig
+++ b/arch/renesas/src/rx65n/Kconfig
@@ -149,7 +149,7 @@ config RX65N_CMT0
 config RX65N_CMT1
 	bool "CMT1"
 	default n
-	depends on BOARD_CRASHDUMP && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
 
 config RX65N_CMT2
 	bool "CMT2"
@@ -170,7 +170,7 @@ config RX65N_IRQ_GROUP
 config RX65N_SBRAM
 	bool "SBRAM"
 	default n
-	depends on BOARD_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM
 
 config RX65N_SAVE_CRASHDUMP
 	bool "SBRAM Save Crashdump"
@@ -541,7 +541,7 @@ config RX65N_CMT0
 config RX65N_CMT1
 	bool "CMT1"
 	default n
-	depends on BOARD_CRASHDUMP && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM && RX65N_SBRAM && RX65N_SAVE_CRASHDUMP
 
 config RX65N_CMT2
 	bool "CMT2"
@@ -562,7 +562,7 @@ config RX65N_IRQ_GROUP
 config RX65N_SBRAM
 	bool "SBRAM"
 	default n
-	depends on BOARD_CRASHDUMP
+	depends on BOARD_CRASHDUMP_CUSTOM
 
 config RX65N_SAVE_CRASHDUMP
 	bool "SBRAM Save Crashdump"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4652,9 +4652,9 @@ source "boards/arm/nrf91/common/Kconfig"
 endif
 endif
 
-config BOARD_CRASHDUMP
-	bool "Enable Board level logging of crash dumps"
-	default n
+choice
+	prompt "BOARD crashdump method"
+	default BOARD_CRASHDUMP_NONE
 	---help---
 		If selected up_assert will call out to board_crashdump, in the case
 		of an assertion failure, prior to calling exit. Or in the
@@ -4671,28 +4671,31 @@ config BOARD_CRASHDUMP
 
 config BOARD_COREDUMP_SYSLOG
 	bool "Enable Core dump to syslog"
-	default n
 	depends on COREDUMP
 	---help---
 		Enable put coredump to syslog when crash.
 
 config BOARD_COREDUMP_BLKDEV
 	bool "Enable Core Dump to block device"
-	default n
 	depends on COREDUMP
 	---help---
-		Enable save coredump at block device when crash.
+		Enable save coredump to block device when crash.
 
-config BOARD_COREDUMP_BLKDEV_PATH
-	string "Save Core Dump block device PATH"
+config BOARD_CRASHDUMP_NONE
+	bool "No Board level crash dump"
+
+endchoice # BOARD crashdump method
+
+config BOARD_COREDUMP_DEVPATH
+	string "Save Core Dump data with device PATH"
 	depends on BOARD_COREDUMP_BLKDEV
 	---help---
-		Save coredump file block device path.
+		Save coredump file into block device path.
 
 config BOARD_COREDUMP_FULL
 	bool "Core Dump all thread registers and stacks"
 	default y
-	depends on BOARD_COREDUMP_SYSLOG || BOARD_COREDUMP_BLKDEV
+	depends on !BOARD_CRASHDUMP_NONE
 	---help---
 		Enable to support for the dump all task registers and stacks.
 
@@ -4700,7 +4703,7 @@ config BOARD_COREDUMP_COMPRESSION
 	bool "Enable Core Dump compression"
 	default y
 	select LIBC_LZF
-	depends on BOARD_COREDUMP_SYSLOG || BOARD_COREDUMP_BLKDEV
+	depends on !BOARD_CRASHDUMP_NONE
 	---help---
 		Enable LZF compression algorithm for core dump content
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4687,6 +4687,12 @@ config BOARD_COREDUMP_MTDDEV
 	---help---
 		Enable save coredump to mtd device when crash.
 
+config BOARD_CRASHDUMP_CUSTOM
+	bool "Enable Core Dump with custom method"
+	---help---
+		Enable save coredump with custom method. only work with
+		board_crashdump api.
+
 config BOARD_CRASHDUMP_NONE
 	bool "No Board level crash dump"
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -4681,6 +4681,12 @@ config BOARD_COREDUMP_BLKDEV
 	---help---
 		Enable save coredump to block device when crash.
 
+config BOARD_COREDUMP_MTDDEV
+	bool "Enable Core Dump to mtd device"
+	depends on COREDUMP
+	---help---
+		Enable save coredump to mtd device when crash.
+
 config BOARD_CRASHDUMP_NONE
 	bool "No Board level crash dump"
 
@@ -4688,9 +4694,9 @@ endchoice # BOARD crashdump method
 
 config BOARD_COREDUMP_DEVPATH
 	string "Save Core Dump data with device PATH"
-	depends on BOARD_COREDUMP_BLKDEV
+	depends on BOARD_COREDUMP_BLKDEV || BOARD_COREDUMP_MTDDEV
 	---help---
-		Save coredump file into block device path.
+		Save coredump file into block/mtd device path.
 
 config BOARD_COREDUMP_FULL
 	bool "Core Dump all thread registers and stacks"

--- a/boards/arm/sama5/sama5d4-ek/src/at25_main.c
+++ b/boards/arm/sama5/sama5d4-ek/src/at25_main.c
@@ -180,7 +180,7 @@ int at25_main(int argc, char *argv[])
   /* The HEX file load was successful, write the data to FLASH */
 
   printf("Successfully loaded the Intel HEX file into memory...\n");
-  printf("  Writing %d bytes to the AT25 Serial FLASH\n",
+  printf("  Writing %" PRIdOFF " bytes to the AT25 Serial FLASH\n",
          memoutstream.common.nput);
 
   remaining = memoutstream.common.nput;
@@ -213,7 +213,7 @@ int at25_main(int argc, char *argv[])
    * the same.
    */
 
-  printf("  Verifying %d bytes in the AT25 Serial FLASH\n",
+  printf("  Verifying %" PRIdOFF " bytes in the AT25 Serial FLASH\n",
          memoutstream.common.nput);
 
   /* Open the AT25 device for writing */
@@ -252,7 +252,7 @@ int at25_main(int argc, char *argv[])
         {
           if (memcmp(g_iobuffer, src, nread) != 0)
             {
-              fprintf(stderr, "ERROR: Verify failed at offset %d\n",
+              fprintf(stderr, "ERROR: Verify failed at offset %"PRIdOFF"\n",
                       memoutstream.common.nput - remaining);
               close(fd);
               return EXIT_FAILURE;
@@ -264,7 +264,7 @@ int at25_main(int argc, char *argv[])
     }
   while (remaining > 0);
 
-  printf("  Successfully verified %d bytes in the AT25 Serial FLASH\n",
+  printf("Successfully verified %"PRIdOFF" bytes in the AT25 Serial FLASH\n",
          memoutstream.common.nput);
 
   close(fd);

--- a/drivers/segger/stream_rtt.c
+++ b/drivers/segger/stream_rtt.c
@@ -52,12 +52,12 @@ static void rttstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: rttstream_puts
  ****************************************************************************/
 
-static int rttstream_puts(FAR struct lib_outstream_s *self,
-                          FAR const void *buf, int len)
+static ssize_t rttstream_puts(FAR struct lib_outstream_s *self,
+                              FAR const void *buf, size_t len)
 {
   FAR struct lib_rttoutstream_s *stream =
                                 (FAR struct lib_rttoutstream_s *)self;
-  int ret;
+  ssize_t ret;
 
   SEGGER_RTT_BLOCK_IF_FIFO_FULL(0);
   ret = SEGGER_RTT_Write(stream->channel, buf, len);
@@ -84,12 +84,12 @@ static int rttstream_getc(FAR struct lib_instream_s *self)
  * Name: rttstream_gets
  ****************************************************************************/
 
-static int rttstream_gets(FAR struct lib_instream_s *self,
-                          FAR void * buffer, int size)
+static ssize_t rttstream_gets(FAR struct lib_instream_s *self,
+                              FAR void * buffer, size_t size)
 {
   FAR struct lib_rttinstream_s *stream =
                                 (FAR struct lib_rttinstream_s *)self;
-  int ret;
+  ssize_t ret;
 
   DEBUGASSERT(stream);
   ret = SEGGER_RTT_Read(stream->channel, buffer, size);

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -820,7 +820,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_BOARD_CRASHDUMP
+#ifdef CONFIG_BOARD_CRASHDUMP_CUSTOM
 struct tcb_s;
 void board_crashdump(uintptr_t sp, FAR struct tcb_s *tcb,
                      FAR const char *filename, int lineno,

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -50,6 +50,7 @@
 #define lib_stream_puts(stream, buf, len) \
         ((FAR struct lib_outstream_s *)(stream))->puts( \
         (FAR struct lib_outstream_s *)(stream), buf, len)
+#define lib_stream_eof(c) ((c) <= 0)
 #define lib_stream_getc(stream) \
         ((FAR struct lib_instream_s *)(stream))->getc( \
         (FAR struct lib_instream_s *)(stream))

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -293,7 +293,7 @@ struct lib_lzfoutstream_s
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 struct lib_blkoutstream_s
 {
-  struct lib_outstream_s common;
+  struct lib_sostream_s  common;
   FAR struct inode      *inode;
   struct geometry        geo;
   FAR unsigned char     *cache;
@@ -303,7 +303,7 @@ struct lib_blkoutstream_s
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_MTD)
 struct lib_mtdoutstream_s
 {
-  struct lib_outstream_s common;
+  struct lib_sostream_s  common;
   FAR struct inode      *inode;
   struct mtd_geometry_s  geo;
   FAR unsigned char     *cache;

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -74,19 +74,19 @@
 /* These are the generic representations of a streams used by the NuttX */
 
 struct lib_instream_s;
-typedef CODE int  (*lib_getc_t)(FAR struct lib_instream_s *self);
-typedef CODE int  (*lib_gets_t)(FAR struct lib_instream_s *self,
-                                FAR void *buf, int len);
+typedef CODE int     (*lib_getc_t)(FAR struct lib_instream_s *self);
+typedef CODE ssize_t (*lib_gets_t)(FAR struct lib_instream_s *self,
+                                   FAR void *buf, size_t len);
 
 struct lib_outstream_s;
-typedef CODE void (*lib_putc_t)(FAR struct lib_outstream_s *self, int ch);
-typedef CODE int  (*lib_puts_t)(FAR struct lib_outstream_s *self,
-                                FAR const void *buf, int len);
-typedef CODE int  (*lib_flush_t)(FAR struct lib_outstream_s *self);
+typedef CODE void    (*lib_putc_t)(FAR struct lib_outstream_s *self, int ch);
+typedef CODE ssize_t (*lib_puts_t)(FAR struct lib_outstream_s *self,
+                                   FAR const void *buf, size_t len);
+typedef CODE int     (*lib_flush_t)(FAR struct lib_outstream_s *self);
 
 struct lib_instream_s
 {
-  int                    nget;    /* Total number of characters gotten.  Written
+  off_t                  nget;    /* Total number of characters gotten.  Written
                                    * by get method, readable by user */
   lib_getc_t             getc;    /* Get one character from the instream */
   lib_gets_t             gets;    /* Get the string from the instream */
@@ -94,7 +94,7 @@ struct lib_instream_s
 
 struct lib_outstream_s
 {
-  int                    nput;    /* Total number of characters put.  Written
+  off_t                  nput;    /* Total number of characters put.  Written
                                    * by put method, readable by user */
   lib_putc_t             putc;    /* Put one character to the outstream */
   lib_puts_t             puts;    /* Writes the string to the outstream */
@@ -104,23 +104,24 @@ struct lib_outstream_s
 /* Seek-able streams */
 
 struct lib_sistream_s;
-typedef CODE int   (*lib_sigetc_t)(FAR struct lib_sistream_s *self);
-typedef CODE int   (*lib_sigets_t)(FAR struct lib_sistream_s *self,
-                                   FAR void *buf, int len);
-typedef CODE off_t (*lib_siseek_t)(FAR struct lib_sistream_s *self,
-                                   off_t offset, int whence);
+typedef CODE int     (*lib_sigetc_t)(FAR struct lib_sistream_s *self);
+typedef CODE ssize_t (*lib_sigets_t)(FAR struct lib_sistream_s *self,
+                                     FAR void *buf, size_t len);
+typedef CODE off_t   (*lib_siseek_t)(FAR struct lib_sistream_s *self,
+                                     off_t offset, int whence);
 
 struct lib_sostream_s;
-typedef CODE void  (*lib_soputc_t)(FAR struct lib_sostream_s *self, int ch);
-typedef CODE int   (*lib_soputs_t)(FAR struct lib_sostream_s *self,
-                                   FAR const void *buf, int len);
-typedef CODE int   (*lib_soflush_t)(FAR struct lib_sostream_s *self);
-typedef CODE off_t (*lib_soseek_t)(FAR struct lib_sostream_s *self,
-                                   off_t offset, int whence);
+typedef CODE void    (*lib_soputc_t)(FAR struct lib_sostream_s *self,
+                                     int ch);
+typedef CODE ssize_t (*lib_soputs_t)(FAR struct lib_sostream_s *self,
+                                     FAR const void *buf, size_t len);
+typedef CODE int     (*lib_soflush_t)(FAR struct lib_sostream_s *self);
+typedef CODE off_t   (*lib_soseek_t)(FAR struct lib_sostream_s *self,
+                                     off_t offset, int whence);
 
 struct lib_sistream_s
 {
-  int                    nget;    /* Total number of characters gotten.  Written
+  off_t                  nget;    /* Total number of characters gotten.  Written
                                    * by get method, readable by user */
   lib_sigetc_t           getc;    /* Get one character from the instream */
   lib_gets_t             gets;    /* Get the string from the instream */
@@ -129,7 +130,7 @@ struct lib_sistream_s
 
 struct lib_sostream_s
 {
-  int                    nput;    /* Total number of characters put.  Written
+  off_t                  nput;    /* Total number of characters put.  Written
                                    * by put method, readable by user */
   lib_soputc_t           putc;    /* Put one character to the outstream */
   lib_soputs_t           puts;    /* Writes the string to the outstream */
@@ -157,7 +158,7 @@ struct lib_memsistream_s
 {
   struct lib_sistream_s  common;
   FAR const char        *buffer;  /* Address of first byte in the buffer */
-  size_t                 offset;  /* Current buffer offset in bytes */
+  off_t                  offset;  /* Current buffer offset in bytes */
   size_t                 buflen;  /* Size of the buffer in bytes */
 };
 
@@ -165,7 +166,7 @@ struct lib_memsostream_s
 {
   struct lib_sostream_s  common;
   FAR char              *buffer;  /* Address of first byte in the buffer */
-  size_t                 offset;  /* Current buffer offset in bytes */
+  off_t                  offset;  /* Current buffer offset in bytes */
   size_t                 buflen;  /* Size of the buffer in bytes */
 };
 
@@ -231,7 +232,7 @@ struct lib_bufferedoutstream_s
 {
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
-  int                         pending;
+  size_t                      pending;
   char                        buffer[CONFIG_STREAM_OUT_BUFFER_SIZE];
 };
 
@@ -239,7 +240,7 @@ struct lib_hexdumpstream_s
 {
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
-  int                         pending;
+  size_t                      pending;
   char                        buffer[CONFIG_STREAM_HEXDUMP_BUFFER_SIZE + 1];
 };
 
@@ -247,9 +248,9 @@ struct lib_base64outstream_s
 {
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
-  int                         pending;
+  size_t                      pending;
   unsigned char               bytes[3];
-  int                         nbytes;
+  size_t                      nbytes;
   char                        buffer[CONFIG_STREAM_BASE64_BUFFER_SIZE + 1];
 };
 
@@ -269,7 +270,7 @@ struct lib_syslograwstream_s
   struct lib_outstream_s common;
 #ifdef CONFIG_SYSLOG_BUFFER
   char buffer[CONFIG_SYSLOG_BUFSIZE];
-  int  offset;
+  off_t offset;
 #endif
   int last_ch;
 };
@@ -282,7 +283,7 @@ struct lib_lzfoutstream_s
   struct lib_outstream_s      common;
   FAR struct lib_outstream_s *backend;
   lzf_state_t                 state;
-  size_t                      offset;
+  off_t                       offset;
   char                        in[LZF_STREAM_BLOCKSIZE];
   char                        out[LZF_MAX_HDR_SIZE + LZF_STREAM_BLOCKSIZE];
 };
@@ -354,13 +355,13 @@ extern struct lib_outstream_s g_lowoutstream;
  ****************************************************************************/
 
 void lib_meminstream(FAR struct lib_meminstream_s *stream,
-                     FAR const char *bufstart, int buflen);
+                     FAR const char *bufstart, size_t buflen);
 void lib_memoutstream(FAR struct lib_memoutstream_s *stream,
-                      FAR char *bufstart, int buflen);
+                      FAR char *bufstart, size_t buflen);
 void lib_memsistream(FAR struct lib_memsistream_s *stream,
-                     FAR const char *bufstart, int buflen);
+                     FAR const char *bufstart, size_t buflen);
 void lib_memsostream(FAR struct lib_memsostream_s *stream,
-                     FAR char *bufstart, int buflen);
+                     FAR char *bufstart, size_t buflen);
 
 /****************************************************************************
  * Name: lib_stdinstream, lib_stdoutstream

--- a/libs/libc/hex2bin/lib_hex2bin.c
+++ b/libs/libc/hex2bin/lib_hex2bin.c
@@ -250,21 +250,21 @@ static int readstream(FAR struct lib_instream_s *instream,
   /* Skip until the beginning of line start code is encountered */
 
   ch = lib_stream_getc(instream);
-  while (ch != RECORD_STARTCODE && ch != EOF)
+  while (ch != RECORD_STARTCODE && !lib_stream_eof(ch))
     {
       ch = lib_stream_getc(instream);
     }
 
   /* Skip over the startcode */
 
-  if (ch != EOF)
+  if (!lib_stream_eof(ch))
     {
       ch = lib_stream_getc(instream);
     }
 
   /* Then read, verify, and buffer until the end of line is encountered */
 
-  while (ch != EOF && nbytes < (MAXRECORD_ASCSIZE - 1))
+  while (!lib_stream_eof(ch) && nbytes < (MAXRECORD_ASCSIZE - 1))
     {
       if (ch == '\n' || ch == '\r')
         {

--- a/libs/libc/misc/lib_kbddecode.c
+++ b/libs/libc/misc/lib_kbddecode.c
@@ -142,7 +142,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* No, ungotten characters.  Check for the beginning of an ESC sequence. */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream */
 
@@ -166,7 +166,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* Check for ESC-[ */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Return the escape character now.  We will
        * return the EOF indication next time.
@@ -192,7 +192,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* Get and verify the special keyboard data to decode */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Unget everything and return the ESC character.
        */
@@ -219,7 +219,7 @@ int kbd_decode(FAR struct lib_instream_s *stream,
   /* Check for the final semicolon */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Unget everything and return the ESC character.
        */

--- a/libs/libc/misc/lib_slcddecode.c
+++ b/libs/libc/misc/lib_slcddecode.c
@@ -180,7 +180,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
   /* No, ungotten characters.  Get the next character from the buffer. */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream (or perhaps an I/O error) */
 
@@ -204,7 +204,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
   /* Get the next character from the buffer */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Return the escape character now.  We will
        * return the EOF indication next time.
@@ -233,7 +233,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
   /* Get the next character from the buffer */
 
   ch = lib_stream_getc(stream);
-  if (ch == EOF)
+  if (lib_stream_eof(ch))
     {
       /* End of file/stream.  Return the ESC now; return the following
        * characters later.
@@ -281,7 +281,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
       /* Get the next character from the buffer */
 
       ch = lib_stream_getc(stream);
-      if (ch == EOF)
+      if (lib_stream_eof(ch))
         {
           /* End of file/stream.  Return the ESC now; return the following
            * characters later.
@@ -314,7 +314,7 @@ enum slcdret_e slcd_decode(FAR struct lib_instream_s *stream,
       /* Get the next character from the buffer */
 
       ch = lib_stream_getc(stream);
-      if (ch == EOF)
+      if (lib_stream_eof(ch))
         {
           /* End of file/stream.  Return the ESC now; return the following
            * characters later.

--- a/libs/libc/obstack/lib_obstack_vprintf.c
+++ b/libs/libc/obstack/lib_obstack_vprintf.c
@@ -42,8 +42,8 @@ struct obstack_stream
  * Private Functions
  ****************************************************************************/
 
-static int obstack_puts(FAR struct lib_outstream_s *self,
-    FAR const void *buf, int len)
+static ssize_t obstack_puts(FAR struct lib_outstream_s *self,
+                            FAR const void *buf, size_t len)
 {
   FAR struct obstack_stream *stream = (FAR struct obstack_stream *)self;
 

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -1149,7 +1149,7 @@ static int vscanf_internal(FAR struct lib_instream_s *stream, FAR int *lastc,
                 {
                   size_t nchars = (size_t) (stream->nget - ngetstart);
 
-                  if (c != EOF)
+                  if (!lib_stream_eof(c))
                     {
                       /* One more character already read */
 

--- a/libs/libc/stdio/lib_vsscanf.c
+++ b/libs/libc/stdio/lib_vsscanf.c
@@ -41,7 +41,7 @@ int vsscanf(FAR const char *buf, FAR const IPTR char *fmt, va_list ap)
 
   /* Initialize a memory stream to freadm from the buffer */
 
-  lib_meminstream(&meminstream, buf, INT_MAX);
+  lib_meminstream(&meminstream, buf, strlen(buf));
 
   /* Then let lib_vscanf do the real work */
 

--- a/libs/libc/stream/lib_base64outstream.c
+++ b/libs/libc/stream/lib_base64outstream.c
@@ -82,18 +82,18 @@ static void base64stream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: base64stream_puts
  ****************************************************************************/
 
-static int base64stream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t base64stream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_base64outstream_s *stream = (FAR void *)self;
   FAR const unsigned char *input = (FAR const unsigned char *)buf;
-  int remaining = len;
+  size_t remaining = len;
 
   if (stream->nbytes)
     {
       /* Flush the first three bytes */
 
-      int n = 3 - stream->nbytes;
+      size_t n = 3 - stream->nbytes;
       if (n > remaining)
         {
           n = remaining;
@@ -118,8 +118,9 @@ static int base64stream_puts(FAR struct lib_outstream_s *self,
 
   while (remaining >= 3)
     {
-      int outlen;
-      int n = (STREAM_BASE64_BUFFER_SIZE - stream->pending) / 4 * 3;
+      size_t outlen;
+      size_t n = (STREAM_BASE64_BUFFER_SIZE - stream->pending) / 4 * 3;
+
       if (n > remaining)
         {
           n = remaining / 3 * 3;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -45,7 +45,7 @@
  * Name: blkoutstream_flush
  ****************************************************************************/
 
-static int blkoutstream_flush(FAR struct lib_outstream_s *self)
+static int blkoutstream_flush(FAR struct lib_sostream_s *self)
 {
   FAR struct lib_blkoutstream_s *stream =
                                  (FAR struct lib_blkoutstream_s *)self;
@@ -62,10 +62,80 @@ static int blkoutstream_flush(FAR struct lib_outstream_s *self)
 }
 
 /****************************************************************************
+ * Name: blkoutstream_seek
+ ****************************************************************************/
+
+static off_t blkoutstream_seek(FAR struct lib_sostream_s *self,
+                               off_t offset, int whence)
+{
+  FAR struct lib_blkoutstream_s *stream =
+                                 (FAR struct lib_blkoutstream_s *)self;
+  size_t sectorsize = stream->geo.geo_sectorsize;
+  off_t streamsize = sectorsize * stream->geo.geo_nsectors;
+  FAR struct inode *inode = stream->inode;
+  off_t sector;
+  off_t ret;
+
+  switch (whence)
+    {
+      case SEEK_SET:
+        break;
+      case SEEK_END:
+        offset += streamsize;
+        break;
+      case SEEK_CUR:
+        offset += self->nput;
+        break;
+      default:
+        return -ENOTSUP;
+    }
+
+  /* Seek to negative value or value larger than maximum size shall fail. */
+
+  if (offset < 0 || offset > streamsize)
+    {
+      return -EINVAL;
+    }
+
+  if (self->nput % sectorsize)
+    {
+      sector = self->nput / sectorsize;
+      if (offset >= sector * sectorsize &&
+          offset < (sector + 1) * sectorsize)
+        {
+          /* Inside same sector */
+
+          goto out;
+        }
+
+      ret = inode->u.i_bops->write(stream->inode, stream->cache,
+                                   sector, 1);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+  if (offset % sectorsize)
+    {
+      ret = inode->u.i_bops->read(inode, stream->cache,
+                                  offset / sectorsize, 1);
+      if (ret < 0)
+        {
+          return ret;
+        }
+    }
+
+out:
+  self->nput = offset;
+  return offset;
+}
+
+/****************************************************************************
  * Name: blkoutstream_puts
  ****************************************************************************/
 
-static ssize_t blkoutstream_puts(FAR struct lib_outstream_s *self,
+static ssize_t blkoutstream_puts(FAR struct lib_sostream_s *self,
                                  FAR const void *buf, size_t len)
 {
   FAR struct lib_blkoutstream_s *stream =
@@ -140,7 +210,7 @@ static ssize_t blkoutstream_puts(FAR struct lib_outstream_s *self,
  * Name: blkoutstream_putc
  ****************************************************************************/
 
-static void blkoutstream_putc(FAR struct lib_outstream_s *self, int ch)
+static void blkoutstream_putc(FAR struct lib_sostream_s *self, int ch)
 {
   char tmp = ch;
   blkoutstream_puts(self, &tmp, 1);
@@ -240,6 +310,7 @@ int lib_blkoutstream_open(FAR struct lib_blkoutstream_s *stream,
   stream->common.putc  = blkoutstream_putc;
   stream->common.puts  = blkoutstream_puts;
   stream->common.flush = blkoutstream_flush;
+  stream->common.seek  = blkoutstream_seek;
 
   return OK;
 }

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -104,11 +104,14 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
         }
       else if (remain < sectorsize)
         {
-          /* Set content to all 0 before caching,
-           * so no random content will be flushed
-           */
+          /* Read sector back to keep as more as possible old data */
 
-          memset(stream->cache, 0, sectorsize);
+          ret = inode->u.i_bops->read(inode, stream->cache, sector, 1);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
           memcpy(stream->cache, ptr, remain);
           self->nput += remain;
           remain      = 0;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -170,6 +170,7 @@ void lib_blkoutstream_close(FAR struct lib_blkoutstream_s *stream)
 
       if (stream->cache != NULL)
         {
+          blkoutstream_flush(&stream->common);
           lib_free(stream->cache);
           stream->cache = NULL;
         }

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -78,7 +78,7 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
 
   while (remain > 0)
     {
-      size_t sblock = self->nput / sectorsize;
+      size_t sector = self->nput / sectorsize;
       size_t offset = self->nput % sectorsize;
 
       if (offset > 0)
@@ -93,28 +93,27 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
           self->nput += copyin;
           remain     -= copyin;
 
-          if (offset == stream->geo.geo_sectorsize)
+          if (offset == sectorsize)
             {
-              ret = inode->u.i_bops->write(inode, stream->cache, sblock, 1);
+              ret = inode->u.i_bops->write(inode, stream->cache, sector, 1);
               if (ret < 0)
                 {
                   return ret;
                 }
             }
         }
-      else if (remain < stream->geo.geo_sectorsize)
+      else if (remain < sectorsize)
         {
           memcpy(stream->cache, ptr, remain);
           self->nput += remain;
           remain      = 0;
         }
-      else if (remain >= stream->geo.geo_sectorsize)
+      else if (remain >= sectorsize)
         {
-          size_t copyin = (remain / stream->geo.geo_sectorsize) *
-                                    stream->geo.geo_sectorsize;
+          size_t copyin = (remain / sectorsize) * sectorsize;
 
-          ret = inode->u.i_bops->write(inode, ptr, sblock,
-                                       remain / stream->geo.geo_sectorsize);
+          ret = inode->u.i_bops->write(inode, ptr, sector,
+                                       remain / sectorsize);
           if (ret < 0)
             {
               return ret;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -104,6 +104,11 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
         }
       else if (remain < sectorsize)
         {
+          /* Set content to all 0 before caching,
+           * so no random content will be flushed
+           */
+
+          memset(stream->cache, 0, sectorsize);
           memcpy(stream->cache, ptr, remain);
           self->nput += remain;
           remain      = 0;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -108,12 +108,12 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
           self->nput += remain;
           remain      = 0;
         }
-      else if (remain >= sectorsize)
+      else
         {
-          size_t copyin = (remain / sectorsize) * sectorsize;
+          size_t nsector = remain / sectorsize;
+          size_t copyin = nsector * sectorsize;
 
-          ret = inode->u.i_bops->write(inode, ptr, sector,
-                                       remain / sectorsize);
+          ret = inode->u.i_bops->write(inode, ptr, sector, nsector);
           if (ret < 0)
             {
               return ret;

--- a/libs/libc/stream/lib_blkoutstream.c
+++ b/libs/libc/stream/lib_blkoutstream.c
@@ -65,8 +65,8 @@ static int blkoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: blkoutstream_puts
  ****************************************************************************/
 
-static int blkoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t blkoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_blkoutstream_s *stream =
                                  (FAR struct lib_blkoutstream_s *)self;
@@ -74,12 +74,12 @@ static int blkoutstream_puts(FAR struct lib_outstream_s *self,
   FAR struct inode *inode = stream->inode;
   FAR const unsigned char *ptr = buf;
   size_t remain = len;
-  int ret;
+  ssize_t ret;
 
   while (remain > 0)
     {
-      size_t sector = self->nput / sectorsize;
-      size_t offset = self->nput % sectorsize;
+      off_t sector = self->nput / sectorsize;
+      off_t offset = self->nput % sectorsize;
 
       if (offset > 0)
         {

--- a/libs/libc/stream/lib_bufferedoutstream.c
+++ b/libs/libc/stream/lib_bufferedoutstream.c
@@ -63,12 +63,12 @@ static int bufferedoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: bufferedoutstream_puts
  ****************************************************************************/
 
-static int bufferedoutstream_puts(FAR struct lib_outstream_s *self,
-                                 FAR const void *buf, int len)
+static ssize_t bufferedoutstream_puts(FAR struct lib_outstream_s *self,
+                                      FAR const void *buf, size_t len)
 {
   FAR struct lib_bufferedoutstream_s *stream =
     (FAR struct lib_bufferedoutstream_s *)self;
-  int ret = len;
+  size_t ret = len;
 
   if (stream->pending + len <= CONFIG_STREAM_OUT_BUFFER_SIZE)
     {

--- a/libs/libc/stream/lib_fileoutstream.c
+++ b/libs/libc/stream/lib_fileoutstream.c
@@ -42,12 +42,12 @@
  * Name: rawoutstream_puts
  ****************************************************************************/
 
-static int fileoutstream_puts(FAR struct lib_outstream_s *self,
-                              FAR const void *buf, int len)
+static ssize_t fileoutstream_puts(FAR struct lib_outstream_s *self,
+                                  FAR const void *buf, size_t len)
 {
   FAR struct lib_fileoutstream_s *stream =
                                   (FAR struct lib_fileoutstream_s *)self;
-  int nwritten;
+  ssize_t nwritten;
 
   do
     {

--- a/libs/libc/stream/lib_hexdumpstream.c
+++ b/libs/libc/stream/lib_hexdumpstream.c
@@ -100,7 +100,7 @@ static int hexdumpstream_flush(FAR struct lib_outstream_s *self)
 static void hexdumpstream_putc(FAR struct lib_outstream_s *self, int ch)
 {
   FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
-  int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
+  size_t outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
   const uint8_t byte = ch;
 
   bin2hex(&byte, 1, stream->buffer + stream->pending,
@@ -120,15 +120,15 @@ static void hexdumpstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: hexdumpstream_puts
  ****************************************************************************/
 
-static int hexdumpstream_puts(FAR struct lib_outstream_s *self,
-                           FAR const void *buf, int len)
+static ssize_t hexdumpstream_puts(FAR struct lib_outstream_s *self,
+                                  FAR const void *buf, size_t len)
 {
   FAR struct lib_hexdumpstream_s *stream = (FAR void *)self;
   const unsigned char *p = buf;
-  int outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
-  int line = outlen / 2;
-  int remain = len;
-  int ret;
+  size_t outlen = CONFIG_STREAM_HEXDUMP_BUFFER_SIZE;
+  size_t line = outlen / 2;
+  size_t remain = len;
+  ssize_t ret;
 
   while (remain > 0)
     {

--- a/libs/libc/stream/lib_lowoutstream.c
+++ b/libs/libc/stream/lib_lowoutstream.c
@@ -40,8 +40,8 @@
  ****************************************************************************/
 
 static void lowoutstream_putc(FAR struct lib_outstream_s *self, int ch);
-static int lowoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len);
+static ssize_t lowoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len);
 
 /****************************************************************************
  * Public Data
@@ -79,8 +79,8 @@ static void lowoutstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: lowoutstream_puts
  ****************************************************************************/
 
-static int lowoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t lowoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   DEBUGASSERT(self);
 

--- a/libs/libc/stream/lib_lzfcompress.c
+++ b/libs/libc/stream/lib_lzfcompress.c
@@ -64,8 +64,8 @@ static int lzfoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: lzfoutstream_puts
  ****************************************************************************/
 
-static int lzfoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t lzfoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_lzfoutstream_s *stream =
                                  (FAR struct lib_lzfoutstream_s *)self;
@@ -74,7 +74,7 @@ static int lzfoutstream_puts(FAR struct lib_outstream_s *self,
   size_t total = len;
   size_t copyin;
   size_t outlen;
-  int ret;
+  ssize_t ret;
 
   while (total > 0)
     {

--- a/libs/libc/stream/lib_meminstream.c
+++ b/libs/libc/stream/lib_meminstream.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 
 #include "libc.h"
@@ -41,7 +42,7 @@ static int meminstream_getc(FAR struct lib_instream_s *self)
 {
   FAR struct lib_meminstream_s *stream =
                                        (FAR struct lib_meminstream_s *)self;
-  int ret;
+  int ret = -EINVAL;
 
   DEBUGASSERT(self);
 
@@ -52,10 +53,6 @@ static int meminstream_getc(FAR struct lib_instream_s *self)
       ret = stream->buffer[self->nget];
       self->nget++;
     }
-  else
-    {
-      ret = EOF;
-    }
 
   return ret;
 }
@@ -64,12 +61,12 @@ static int meminstream_getc(FAR struct lib_instream_s *self)
  * Name: meminstream_gets
  ****************************************************************************/
 
-static int meminstream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t meminstream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_meminstream_s *stream =
                                        (FAR struct lib_meminstream_s *)self;
-  int ret;
+  ssize_t ret = -EINVAL;
 
   DEBUGASSERT(self);
 
@@ -81,10 +78,6 @@ static int meminstream_gets(FAR struct lib_instream_s *self,
             stream->buflen - self->nget : len;
       self->nget += ret;
       memcpy(buffer, stream->buffer, ret);
-    }
-  else
-    {
-      ret = EOF;
     }
 
   return ret;
@@ -112,7 +105,7 @@ static int meminstream_gets(FAR struct lib_instream_s *self,
  ****************************************************************************/
 
 void lib_meminstream(FAR struct lib_meminstream_s *stream,
-                     FAR const char *bufstart, int buflen)
+                     FAR const char *bufstart, size_t buflen)
 {
   stream->common.getc = meminstream_getc;
   stream->common.gets = meminstream_gets;

--- a/libs/libc/stream/lib_memoutstream.c
+++ b/libs/libc/stream/lib_memoutstream.c
@@ -36,12 +36,12 @@
  * Name: memoutstream_puts
  ****************************************************************************/
 
-static int memoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t memoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_memoutstream_s *stream =
                                 (FAR struct lib_memoutstream_s *)self;
-  int ncopy;
+  size_t ncopy;
 
   DEBUGASSERT(self);
 
@@ -94,7 +94,7 @@ static void memoutstream_putc(FAR struct lib_outstream_s *self, int ch)
  ****************************************************************************/
 
 void lib_memoutstream(FAR struct lib_memoutstream_s *outstream,
-                      FAR char *bufstart, int buflen)
+                      FAR char *bufstart, size_t buflen)
 {
   outstream->common.putc  = memoutstream_putc;
   outstream->common.puts  = memoutstream_puts;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -296,7 +296,7 @@ int lib_mtdoutstream_open(FAR struct lib_mtdoutstream_s *stream,
   if (node->u.i_mtd->write == NULL)
 #endif
     {
-      stream->cache = lib_zalloc(stream->geo.erasesize);
+      stream->cache = lib_malloc(stream->geo.erasesize);
       if (stream->cache == NULL)
         {
           close_mtddriver(node);

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -104,9 +104,12 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
 #ifdef CONFIG_MTD_BYTE_WRITE
   if (inode->u.i_mtd->write != NULL)
     {
-      if (self->nput % erasesize == 0)
+      size_t sblock = (self->nput + erasesize - 1) / erasesize;
+      size_t eblock = (self->nput + len + erasesize - 1) / erasesize;
+
+      if (sblock != eblock)
         {
-          ret = MTD_ERASE(inode->u.i_mtd, self->nput / erasesize, 1);
+          ret = MTD_ERASE(inode->u.i_mtd, sblock, eblock - sblock);
           if (ret < 0)
             {
               return ret;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -77,8 +77,8 @@ static int mtdoutstream_flush(FAR struct lib_outstream_s *self)
  * Name: mtdoutstream_puts
  ****************************************************************************/
 
-static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t mtdoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_mtdoutstream_s *stream =
     (FAR struct lib_mtdoutstream_s *)self;
@@ -87,7 +87,7 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
   size_t erasesize = stream->geo.erasesize;
   size_t nblkpererase = erasesize / stream->geo.blocksize;
   size_t remain = len;
-  int ret;
+  ssize_t ret;
 
   if (self->nput + len > erasesize * stream->geo.neraseblocks)
     {
@@ -96,8 +96,8 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
 
   while (remain > 0)
     {
-      size_t sblock = self->nput / erasesize;
-      size_t offset = self->nput % erasesize;
+      off_t sblock = self->nput / erasesize;
+      off_t offset = self->nput % erasesize;
 
       if (offset > 0)
         {

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -102,10 +102,9 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
 #ifdef CONFIG_MTD_BYTE_WRITE
   if (stream->inode->u.i_mtd->write != NULL)
     {
-      if (self->nput % stream->geo.erasesize == 0)
+      if (self->nput % erasesize == 0)
         {
-          ret = MTD_ERASE(inode->u.i_mtd,
-                          self->nput / stream->geo.erasesize, 1);
+          ret = MTD_ERASE(inode->u.i_mtd, self->nput / erasesize, 1);
           if (ret < 0)
             {
               return ret;
@@ -162,7 +161,7 @@ static int mtdoutstream_puts(FAR struct lib_outstream_s *self,
                * so no random content will be flushed
                */
 
-              memset(stream->cache, 0, stream->geo.erasesize);
+              memset(stream->cache, 0, erasesize);
               memcpy(stream->cache, ptr, remain);
               self->nput += remain;
               remain      = 0;

--- a/libs/libc/stream/lib_mtdoutstream.c
+++ b/libs/libc/stream/lib_mtdoutstream.c
@@ -237,6 +237,7 @@ void lib_mtdoutstream_close(FAR struct lib_mtdoutstream_s *stream)
 
       if (stream->cache != NULL)
         {
+          mtdoutstream_flush(&stream->common);
           lib_free(stream->cache);
           stream->cache = NULL;
         }

--- a/libs/libc/stream/lib_nullinstream.c
+++ b/libs/libc/stream/lib_nullinstream.c
@@ -36,15 +36,15 @@
 static int nullinstream_getc(FAR struct lib_instream_s *self)
 {
   UNUSED(self);
-  return EOF;
+  return -EINVAL;
 }
 
-static int nullinstream_gets(FAR struct lib_instream_s *self,
-                             FAR void *buffer, int len)
+static ssize_t nullinstream_gets(FAR struct lib_instream_s *self,
+                                 FAR void *buffer, size_t len)
 {
   UNUSED(buffer);
   UNUSED(len);
-  return EOF;
+  return -EINVAL;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_nulloutstream.c
+++ b/libs/libc/stream/lib_nulloutstream.c
@@ -41,8 +41,8 @@ static void nulloutstream_putc(FAR struct lib_outstream_s *self, int ch)
   self->nput++;
 }
 
-static int nulloutstream_puts(FAR struct lib_outstream_s *self,
-                              FAR const void *buffer, int len)
+static ssize_t nulloutstream_puts(FAR struct lib_outstream_s *self,
+                                  FAR const void *buffer, size_t len)
 {
   UNUSED(buffer);
   UNUSED(len);

--- a/libs/libc/stream/lib_rawinstream.c
+++ b/libs/libc/stream/lib_rawinstream.c
@@ -59,26 +59,22 @@ static int rawinstream_getc(FAR struct lib_instream_s *self)
       self->nget++;
       return ch;
     }
-
-  /* Return EOF on any failure to read from the incoming byte stream. The
-   * only expected error is EINTR meaning that the read was interrupted
-   * by a signal.  A Zero return value would indicate an end-of-file
-   * condition.
-   */
-
-  return EOF;
+  else
+    {
+      return _NX_GETERRVAL(nread);
+    }
 }
 
 /****************************************************************************
  * Name: rawinstream_getc
  ****************************************************************************/
 
-static int rawinstream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t rawinstream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_rawinstream_s *stream =
                                        (FAR struct lib_rawinstream_s *)self;
-  int nread;
+  ssize_t nread;
 
   DEBUGASSERT(self && stream->fd >= 0);
 

--- a/libs/libc/stream/lib_rawoutstream.c
+++ b/libs/libc/stream/lib_rawoutstream.c
@@ -42,12 +42,12 @@
  * Name: rawoutstream_puts
  ****************************************************************************/
 
-static int rawoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buf, int len)
+static ssize_t rawoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buf, size_t len)
 {
   FAR struct lib_rawoutstream_s *stream =
                                 (FAR struct lib_rawoutstream_s *)self;
-  int nwritten = 0;
+  ssize_t nwritten = 0;
 
   do
     {

--- a/libs/libc/stream/lib_rawsistream.c
+++ b/libs/libc/stream/lib_rawsistream.c
@@ -59,26 +59,22 @@ static int rawsistream_getc(FAR struct lib_sistream_s *self)
       self->nget++;
       return ch;
     }
-
-  /* Return EOF on any failure to read from the incoming byte stream. The
-   * only expected error is EINTR meaning that the read was interrupted
-   * by a signal.  A Zero return value would indicated an end-of-file
-   * confition.
-   */
-
-  return EOF;
+  else
+    {
+      return _NX_GETERRVAL(nread);
+    }
 }
 
 /****************************************************************************
  * Name: rawsistream_gets
  ****************************************************************************/
 
-static int rawsistream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t rawsistream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_rawsistream_s *stream =
                                        (FAR struct lib_rawsistream_s *)self;
-  int nread;
+  ssize_t nread;
 
   DEBUGASSERT(self && stream->fd >= 0);
 
@@ -108,7 +104,13 @@ static off_t rawsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                                        (FAR struct lib_rawsistream_s *)self;
 
   DEBUGASSERT(self);
-  return _NX_SEEK(stream->fd, offset, whence);
+  offset = _NX_SEEK(stream->fd, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_rawsostream.c
+++ b/libs/libc/stream/lib_rawsostream.c
@@ -47,7 +47,7 @@ static void rawsostream_putc(FAR struct lib_sostream_s *self, int ch)
   FAR struct lib_rawsostream_s *stream =
                                        (FAR struct lib_rawsostream_s *)self;
   char buffer = ch;
-  int nwritten;
+  ssize_t nwritten;
 
   DEBUGASSERT(self && stream->fd >= 0);
 
@@ -79,12 +79,12 @@ static void rawsostream_putc(FAR struct lib_sostream_s *self, int ch)
  * Name: rawsostream_puts
  ****************************************************************************/
 
-static int rawsostream_puts(FAR struct lib_sostream_s *self,
-                            FAR const void *buffer, int len)
+static ssize_t rawsostream_puts(FAR struct lib_sostream_s *self,
+                                FAR const void *buffer, size_t len)
 {
   FAR struct lib_rawsostream_s *stream =
                                        (FAR struct lib_rawsostream_s *)self;
-  int nwritten;
+  ssize_t nwritten;
 
   DEBUGASSERT(self && stream->fd >= 0);
 
@@ -125,7 +125,13 @@ static off_t rawsostream_seek(FAR struct lib_sostream_s *self, off_t offset,
                                        (FAR struct lib_rawsostream_s *)self;
 
   DEBUGASSERT(self);
-  return _NX_SEEK(stream->fd, offset, whence);
+  offset = _NX_SEEK(stream->fd, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_stdinstream.c
+++ b/libs/libc/stream/lib_stdinstream.c
@@ -60,12 +60,12 @@ static int stdinstream_getc(FAR struct lib_instream_s *self)
  * Name: stdinstream_gets
  ****************************************************************************/
 
-static int stdinstream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t stdinstream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_stdinstream_s *stream =
                                        (FAR struct lib_stdinstream_s *)self;
-  int nread = 0;
+  ssize_t nread = 0;
 
   DEBUGASSERT(self);
 

--- a/libs/libc/stream/lib_stdinstream.c
+++ b/libs/libc/stream/lib_stdinstream.c
@@ -52,6 +52,10 @@ static int stdinstream_getc(FAR struct lib_instream_s *self)
     {
       self->nget++;
     }
+  else
+    {
+      ret = _NX_GETERRVAL(ret);
+    }
 
   return ret;
 }

--- a/libs/libc/stream/lib_stdoutstream.c
+++ b/libs/libc/stream/lib_stdoutstream.c
@@ -71,12 +71,12 @@ static void stdoutstream_putc(FAR struct lib_outstream_s *self, int ch)
  * Name: stdoutstream_puts
  ****************************************************************************/
 
-static int stdoutstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buffer, int len)
+static ssize_t stdoutstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buffer, size_t len)
 {
   FAR struct lib_stdoutstream_s *stream =
                                (FAR struct lib_stdoutstream_s *)self;
-  int result;
+  ssize_t result;
 
   DEBUGASSERT(self && stream->handle);
 

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -51,6 +51,10 @@ static int stdsistream_getc(FAR struct lib_sistream_s *self)
     {
       self->nget++;
     }
+  else
+    {
+      ret = _NX_GETERRVAL(ret);
+    }
 
   return ret;
 }

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -59,12 +59,12 @@ static int stdsistream_getc(FAR struct lib_sistream_s *self)
  * Name: stdsistream_gets
  ****************************************************************************/
 
-static int stdsistream_gets(FAR struct lib_instream_s *self,
-                            FAR void *buffer, int len)
+static ssize_t stdsistream_gets(FAR struct lib_instream_s *self,
+                                FAR void *buffer, size_t len)
 {
   FAR struct lib_stdsistream_s *stream =
                                         (FAR struct lib_stdsistream_s *)self;
-  int nread = 0;
+  ssize_t nread = 0;
 
   DEBUGASSERT(self);
 
@@ -94,7 +94,13 @@ static off_t stdsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
                                         (FAR struct lib_stdsistream_s *)self;
 
   DEBUGASSERT(self);
-  return fseek(stream->handle, offset, whence);
+  offset = fseek(stream->handle, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_stdsostream.c
+++ b/libs/libc/stream/lib_stdsostream.c
@@ -70,12 +70,12 @@ static void stdsostream_putc(FAR struct lib_sostream_s *self, int ch)
  * Name: stdsostream_puts
  ****************************************************************************/
 
-static int stdsostream_puts(FAR struct lib_sostream_s *self,
-                            FAR const void *buffer, int len)
+static ssize_t stdsostream_puts(FAR struct lib_sostream_s *self,
+                                FAR const void *buffer, size_t len)
 {
   FAR struct lib_stdsostream_s *stream =
                                         (FAR struct lib_stdsostream_s *)self;
-  int result;
+  ssize_t result;
 
   DEBUGASSERT(self && stream->handle);
 
@@ -129,7 +129,13 @@ static off_t stdsostream_seek(FAR struct lib_sostream_s *self, off_t offset,
                                         (FAR struct lib_stdsostream_s *)self;
 
   DEBUGASSERT(stream != NULL && stream->handle != NULL);
-  return fseek(stream->handle, offset, whence);
+  offset = fseek(stream->handle, offset, whence);
+  if (offset < 0)
+    {
+      offset = _NX_GETERRVAL(offset);
+    }
+
+  return offset;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_syslograwstream.c
+++ b/libs/libc/stream/lib_syslograwstream.c
@@ -102,15 +102,15 @@ static void syslograwstream_addchar(FAR struct lib_syslograwstream_s *stream,
  * Name: syslograwstream_addstring
  ****************************************************************************/
 
-static int
+static ssize_t
 syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
-                          FAR const char *buff, int len)
+                          FAR const char *buff, size_t len)
 {
-  int ret = 0;
+  ssize_t ret = 0;
 
   do
     {
-      int remain = CONFIG_SYSLOG_BUFSIZE - stream->offset;
+      size_t remain = CONFIG_SYSLOG_BUFSIZE - stream->offset;
       remain = remain > len - ret ? len - ret : remain;
       memcpy(stream->buffer + stream->offset, buff + ret, remain);
       stream->offset += remain;
@@ -183,8 +183,8 @@ static void syslograwstream_putc(FAR struct lib_outstream_s *self, int ch)
     }
 }
 
-static int syslograwstream_puts(FAR struct lib_outstream_s *self,
-                                FAR const void *buff, int len)
+static ssize_t syslograwstream_puts(FAR struct lib_outstream_s *self,
+                                    FAR const void *buff, size_t len)
 {
   FAR struct lib_syslograwstream_s *stream = (FAR void *)self;
 
@@ -202,7 +202,7 @@ static int syslograwstream_puts(FAR struct lib_outstream_s *self,
 
   return syslograwstream_addstring(stream, buff, len);
 #else
-  int ret;
+  ssize_t ret;
 
   /* Try writing until the write was successful or until an
    * irrecoverable error occurs.

--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -49,8 +49,8 @@ static void syslogstream_putc(FAR struct lib_outstream_s *self, int ch)
   stream->common.nput++;
 }
 
-static int syslogstream_puts(FAR struct lib_outstream_s *self,
-                             FAR const void *buff, int len)
+static ssize_t syslogstream_puts(FAR struct lib_outstream_s *self,
+                                 FAR const void *buff, size_t len)
 {
   FAR struct lib_syslogstream_s *stream =
                                        (FAR struct lib_syslogstream_s *)self;
@@ -61,7 +61,7 @@ static int syslogstream_puts(FAR struct lib_outstream_s *self,
       return 0;
     }
 
-  syslog(stream->priority, "%.*s", len, (FAR const char *)buff);
+  syslog(stream->priority, "%.*s", (int)len, (FAR const char *)buff);
   return len;
 }
 

--- a/libs/libc/stream/lib_zeroinstream.c
+++ b/libs/libc/stream/lib_zeroinstream.c
@@ -38,8 +38,8 @@ static int zeroinstream_getc(FAR struct lib_instream_s *self)
   return 0;
 }
 
-static int zeroinstream_gets(FAR struct lib_instream_s *self,
-                             FAR void *buffer, int len)
+static ssize_t zeroinstream_gets(FAR struct lib_instream_s *self,
+                                 FAR void *buffer, size_t len)
 {
   self->nget += len;
   memset(buffer, 0, len);

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -322,8 +322,7 @@ static inline void nx_start_application(void)
   board_late_initialize();
 #endif
 
-#if defined(CONFIG_BOARD_COREDUMP_SYSLOG) || \
-    defined(CONFIG_BOARD_COREDUMP_BLKDEV)
+#ifndef CONFIG_BOARD_CRASHDUMP_NONE
   coredump_initialize();
 #endif
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -750,14 +750,13 @@ static void dump_fatal_info(FAR struct tcb_s *rtcb,
   usbtrace_enumerate(assert_tracecallback, NULL);
 #endif
 
-#ifdef CONFIG_BOARD_CRASHDUMP
-  board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
-#endif
-
-#ifndef CONFIG_BOARD_CRASHDUMP_NONE
   /* Flush previous SYSLOG data before possible long time coredump */
 
   syslog_flush();
+
+#ifdef CONFIG_BOARD_CRASHDUMP_CUSTOM
+  board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
+#elif !defined(CONFIG_BOARD_CRASHDUMP_NONE)
 
   /* Dump core information */
 

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -754,9 +754,7 @@ static void dump_fatal_info(FAR struct tcb_s *rtcb,
   board_crashdump(up_getsp(), rtcb, filename, linenum, msg, regs);
 #endif
 
-#if defined(CONFIG_BOARD_COREDUMP_SYSLOG) || \
-    defined(CONFIG_BOARD_COREDUMP_BLKDEV)
-
+#ifndef CONFIG_BOARD_CRASHDUMP_NONE
   /* Flush previous SYSLOG data before possible long time coredump */
 
   syslog_flush();

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -47,6 +47,10 @@
 #  define ELF_PAGESIZE    1024
 #endif
 
+#ifdef CONFIG_BOARD_COREDUMP_BLKDEV
+#  define CONFIG_BOARD_COREDUMP_DEV
+#endif
+
 #define PROGRAM_ALIGNMENT 64
 
 #define ROUNDUP(x, y)     ((x + (y - 1)) / (y)) * (y)
@@ -87,8 +91,7 @@ static struct lib_hexdumpstream_s g_hexstream;
 #endif
 
 #ifdef CONFIG_BOARD_COREDUMP_BLKDEV
-static struct lib_blkoutstream_s  g_blockstream;
-static unsigned char *g_blockinfo;
+static struct lib_blkoutstream_s g_devstream;
 #endif
 
 #ifdef CONFIG_BOARD_MEMORY_RANGE
@@ -670,77 +673,73 @@ static void coredump_dump_syslog(pid_t pid)
 #endif
 
 /****************************************************************************
- * Name: coredump_dump_blkdev
+ * Name: coredump_dump_dev
  *
  * Description:
- *   Save coredump to block device.
+ *   Save coredump to storage device.
  *
  ****************************************************************************/
 
-#ifdef CONFIG_BOARD_COREDUMP_BLKDEV
-static void coredump_dump_blkdev(pid_t pid)
+#ifdef CONFIG_BOARD_COREDUMP_DEV
+static void coredump_dump_dev(pid_t pid)
 {
-  FAR void *stream = &g_blockstream;
-  FAR struct coredump_info_s *info;
-  blkcnt_t nsectors;
+  FAR void *stream = &g_devstream;
+  FAR struct coredump_info_s info;
   int ret;
 
-  if (g_blockstream.inode == NULL)
+  if (g_devstream.inode == NULL)
     {
       _alert("Coredump device not found\n");
       return;
     }
 
-  nsectors = (sizeof(struct coredump_info_s) +
-              g_blockstream.geo.geo_sectorsize - 1) /
-             g_blockstream.geo.geo_sectorsize;
-
-  ret = g_blockstream.inode->u.i_bops->read(g_blockstream.inode,
-           g_blockinfo, g_blockstream.geo.geo_nsectors - nsectors, nsectors);
-  if (ret < 0)
-    {
-      _alert("Coredump information read fail\n");
-      return;
-    }
-
-  info = (FAR struct coredump_info_s *)g_blockinfo;
-
 #ifdef CONFIG_BOARD_COREDUMP_COMPRESSION
-  lib_lzfoutstream(&g_lzfstream,
-                   (FAR struct lib_outstream_s *)&g_blockstream);
+  lib_lzfoutstream(&g_lzfstream, stream);
   stream = &g_lzfstream;
 #endif
-
   ret = coredump(g_regions, stream, pid);
   if (ret < 0)
     {
-      _alert("Coredump fail\n");
+      _alert("Coredump fail %d\n", ret);
       return;
     }
 
-  info->magic = COREDUMP_MAGIC;
-  info->size  = g_blockstream.common.nput;
-  clock_gettime(CLOCK_REALTIME, &info->time);
-  uname(&info->name);
-  ret = g_blockstream.inode->u.i_bops->write(g_blockstream.inode,
-      (FAR void *)info, g_blockstream.geo.geo_nsectors - nsectors, nsectors);
+  info.magic = COREDUMP_MAGIC;
+  info.size  = g_devstream.common.nput;
+  clock_gettime(CLOCK_REALTIME, &info.time);
+  uname(&info.name);
+
+  ret = lib_stream_seek(&g_devstream, -(off_t)sizeof(info), SEEK_END);
   if (ret < 0)
     {
-      _alert("Coredump information write fail\n");
+      _alert("Coredump info seek fail %d\n", ret);
       return;
     }
 
-  /* Close block device directly, make sure all data write to block device */
+  if (info.size > ret)
+    {
+      _alert("Coredump no enough space for info\n");
+      return;
+    }
 
-  ret = g_blockstream.inode->u.i_bops->close(g_blockstream.inode);
+  ret = lib_stream_puts(&g_devstream, &info, sizeof(info));
   if (ret < 0)
     {
-      _alert("Coredump information close fail\n");
+      _alert("Coredump information write fail %d\n", ret);
       return;
     }
 
-  _alert("Finish coredump, write %d bytes to %s\n",
-         info->size, CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
+  /* Flush to ensure outstream write all data to storage device */
+
+  ret = lib_stream_flush(&g_devstream);
+  if (ret < 0)
+    {
+      _alert("Coredump flush fail %d\n", ret);
+      return;
+    }
+
+  _alert("Finish coredump, write %zu bytes to %s\n",
+         info.size, CONFIG_BOARD_COREDUMP_DEVPATH);
 }
 #endif
 
@@ -859,7 +858,6 @@ int coredump_add_memory_region(FAR const void *ptr, size_t size,
 
 int coredump_initialize(void)
 {
-  blkcnt_t nsectors;
   int ret = 0;
 
 #ifdef CONFIG_BOARD_MEMORY_RANGE
@@ -867,29 +865,15 @@ int coredump_initialize(void)
 #endif
 
 #ifdef CONFIG_BOARD_COREDUMP_BLKDEV
-  ret = lib_blkoutstream_open(&g_blockstream,
-                              CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
+  ret = lib_blkoutstream_open(&g_devstream,
+                              CONFIG_BOARD_COREDUMP_DEVPATH);
   if (ret < 0)
     {
-      _alert("%s Coredump device not found\n",
-             CONFIG_BOARD_COREDUMP_BLKDEV_PATH);
-      return ret;
-    }
-
-  nsectors = (sizeof(struct coredump_info_s) +
-              g_blockstream.geo.geo_sectorsize - 1) /
-             g_blockstream.geo.geo_sectorsize;
-
-  g_blockinfo = kmm_malloc(g_blockstream.geo.geo_sectorsize * nsectors);
-  if (g_blockinfo == NULL)
-    {
-      _alert("Coredump device memory alloc fail\n");
-      lib_blkoutstream_close(&g_blockstream);
-      return -ENOMEM;
+      _alert("%s Coredump device not found %d\n",
+             CONFIG_BOARD_COREDUMP_DEVPATH, ret);
     }
 #endif
 
-  UNUSED(nsectors);
   return ret;
 }
 
@@ -910,8 +894,8 @@ void coredump_dump(pid_t pid)
   coredump_dump_syslog(pid);
 #endif
 
-#ifdef CONFIG_BOARD_COREDUMP_BLKDEV
-  coredump_dump_blkdev(pid);
+#ifdef CONFIG_BOARD_COREDUMP_DEV
+  coredump_dump_dev(pid);
 #endif
 }
 

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -687,7 +687,7 @@ static void coredump_dump_syslog(pid_t pid)
 static void coredump_dump_dev(pid_t pid)
 {
   FAR void *stream = &g_devstream;
-  FAR struct coredump_info_s info;
+  struct coredump_info_s info;
   int ret;
 
   if (g_devstream.inode == NULL)

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -170,7 +170,7 @@ static int elf_emit_align(FAR struct elf_dumpinfo_s *cinfo)
                         ELF_PAGESIZE) - cinfo->stream->nput;
   unsigned char null[256];
   off_t total = align;
-  off_t ret;
+  off_t ret = 0;
 
   memset(null, 0, sizeof(null));
 

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -47,7 +47,8 @@
 #  define ELF_PAGESIZE    1024
 #endif
 
-#ifdef CONFIG_BOARD_COREDUMP_BLKDEV
+#if defined(CONFIG_BOARD_COREDUMP_BLKDEV) || \
+    defined(CONFIG_BOARD_COREDUMP_MTDDEV)
 #  define CONFIG_BOARD_COREDUMP_DEV
 #endif
 
@@ -92,6 +93,8 @@ static struct lib_hexdumpstream_s g_hexstream;
 
 #ifdef CONFIG_BOARD_COREDUMP_BLKDEV
 static struct lib_blkoutstream_s g_devstream;
+#elif defined(CONFIG_BOARD_COREDUMP_MTDDEV)
+static struct lib_mtdoutstream_s g_devstream;
 #endif
 
 #ifdef CONFIG_BOARD_MEMORY_RANGE
@@ -867,6 +870,12 @@ int coredump_initialize(void)
 #ifdef CONFIG_BOARD_COREDUMP_BLKDEV
   ret = lib_blkoutstream_open(&g_devstream,
                               CONFIG_BOARD_COREDUMP_DEVPATH);
+#elif defined(CONFIG_BOARD_COREDUMP_MTDDEV)
+  ret = lib_mtdoutstream_open(&g_devstream,
+                              CONFIG_BOARD_COREDUMP_DEVPATH);
+#endif
+
+#ifdef CONFIG_BOARD_COREDUMP_DEV
   if (ret < 0)
     {
       _alert("%s Coredump device not found %d\n",


### PR DESCRIPTION
block/mtd stream device now support seek API.
coredump use seek to write information, to make sure the coredump exactly use size can be recognize and not relative to geo information.

should work with 
https://github.com/open-vela/nuttx-apps/pull/22
at same time to make sure the repo can finsh whole
panic -> backup to mtd/blk -> reboot -> restore to fs
work flow