### PR TITLE
Greenhills support: fix the naked_function inline asm expansion compile error

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -83,22 +83,22 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " push {r4, r5}\n"                             /* Save R4 and R5 */
-    " sub sp, sp, #12\n"                           /* Create a stack frame to hold 3 parms */
-    " str r4, [sp, #0]\n"                          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"                          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"                          /* Move parameter 6 (if any) into position */
-    " mov r5, lr\n"                                /* Save lr in R5 */
-    " ldr r4, =g_stublookup\n"                     /* R4=The base of the stub lookup table */
-    " lsl r0, r0, #2\n"                            /* R0=Offset of the stub for this syscall */
-    " ldr r4, [r4, r0]\n"                          /* R4=Address of the stub for this syscall */
-    " blx r5\n"                                    /* Call the stub (modifies lr) */
-    " mov lr, r5\n"                                /* Restore lr */
-    " add sp, sp, #12\n"                           /* Destroy the stack frame */
-    " pop {r4, r5}\n"                              /* Recover R4 and R5 */
-    " mov r2, r0\n"                                /* R2=Save return value in R2 */
-    " mov r0, " STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-    " svc " STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
+    " push {r4, r5}\n"                              /* Save R4 and R5 */
+    " sub sp, sp, #12\n"                            /* Create a stack frame to hold 3 parms */
+    " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+    " mov r5, lr\n"                                 /* Save lr in R5 */
+    " ldr r4, =g_stublookup\n"                      /* R4=The base of the stub lookup table */
+    " lsl r0, r0, #2\n"                             /* R0=Offset of the stub for this syscall */
+    " ldr r4, [r4, r0]\n"                           /* R4=Address of the stub for this syscall */
+    " blx r5\n"                                     /* Call the stub (modifies lr) */
+    " mov lr, r5\n"                                 /* Restore lr */
+    " add sp, sp, #12\n"                            /* Destroy the stack frame */
+    " pop {r4, r5}\n"                               /* Recover R4 and R5 */
+    " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -92,7 +92,7 @@ static void dispatch_syscall(void)
     " ldr r4, =g_stublookup\n"                      /* R4=The base of the stub lookup table */
     " lsl r0, r0, #2\n"                             /* R0=Offset of the stub for this syscall */
     " ldr r4, [r4, r0]\n"                           /* R4=Address of the stub for this syscall */
-    " blx r5\n"                                     /* Call the stub (modifies lr) */
+    " blx r4\n"                                     /* Call the stub (modifies lr) */
     " mov lr, r5\n"                                 /* Restore lr */
     " add sp, sp, #12\n"                            /* Destroy the stack frame */
     " pop {r4, r5}\n"                               /* Recover R4 and R5 */

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -124,19 +124,19 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " sub sp, sp, #16\n"                           /* Create a stack frame to hold 3 parms + lr */
-    " str r4, [sp, #0]\n"                          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"                          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"                          /* Move parameter 6 (if any) into position */
-    " str lr, [sp, #12]\n"                         /* Save lr in the stack frame */
-    " ldr ip, =g_stublookup\n"                     /* R12=The base of the stub lookup table */
-    " ldr ip, [ip, r0, lsl #2]\n"                  /* R12=The address of the stub for this SYSCALL */
-    " blx ip\n"                                    /* Call the stub (modifies lr) */
-    " ldr lr, [sp, #12]\n"                         /* Restore lr */
-    " add sp, sp, #16\n"                           /* Destroy the stack frame */
-    " mov r2, r0\n"                                /* R2=Save return value in R2 */
-    " mov r0, " STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-    " svc " STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
+    " sub sp, sp, #16\n"                             /* Create a stack frame to hold 3 parms + lr */
+    " str r4, [sp, #0]\n"                            /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                            /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                            /* Move parameter 6 (if any) into position */
+    " str lr, [sp, #12]\n"                           /* Save lr in the stack frame */
+    " ldr ip, =g_stublookup\n"                       /* R12=The base of the stub lookup table */
+    " ldr ip, [ip, r0, lsl #2]\n"                    /* R12=The address of the stub for this SYSCALL */
+    " blx ip\n"                                      /* Call the stub (modifies lr) */
+    " ldr lr, [sp, #12]\n"                           /* Restore lr */
+    " add sp, sp, #16\n"                             /* Destroy the stack frame */
+    " mov r2, r0\n"                                  /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n"  /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"             /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -88,25 +88,25 @@ static void dispatch_syscall(void)
        *              = orig_SP - 20 - ((orig_SP - 20) & ~7)
        */
 
-      " mov ip, sp\n"                                /* Calculate (orig_SP - new_SP) */
+      " mov ip, sp\n"                                 /* Calculate (orig_SP - new_SP) */
       " sub ip, ip, #20\n"
       " and ip, ip, #7\n"
       " add ip, ip, #20\n"
       " sub sp, sp, ip\n"
-      " str r4, [sp, #0]\n"                          /* Move parameter 4 (if any) into position */
-      " str r5, [sp, #4]\n"                          /* Move parameter 5 (if any) into position */
-      " str r6, [sp, #8]\n"                          /* Move parameter 6 (if any) into position */
-      " str lr, [sp, #12]\n"                         /* Save lr in the stack frame */
-      " str ip, [sp, #16]\n"                         /* Save (orig_SP - new_SP) value */
-      " ldr ip, =g_stublookup\n"                     /* R12=The base of the stub lookup table */
-      " ldr ip, [ip, r0, lsl #2]\n"                  /* R12=The address of the stub for this syscall */
-      " blx ip\n"                                    /* Call the stub (modifies lr) */
-      " ldr lr, [sp, #12]\n"                         /* Restore lr */
-      " ldr r2, [sp, #16]\n"                         /* Restore (orig_SP - new_SP) value */
-      " add sp, sp, r2\n"                            /* Restore SP */
-      " mov r2, r0\n"                                /* R2=Save return value in R2 */
-      " mov r0, " STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-      " svc " STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
+      " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+      " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+      " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+      " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+      " str ip, [sp, #16]\n"                          /* Save (orig_SP - new_SP) value */
+      " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+      " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this syscall */
+      " blx ip\n"                                     /* Call the stub (modifies lr) */
+      " ldr lr, [sp, #12]\n"                          /* Restore lr */
+      " ldr r2, [sp, #16]\n"                          /* Restore (orig_SP - new_SP) value */
+      " add sp, sp, r2\n"                             /* Restore SP */
+      " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+      " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+      " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
     );
 }
 #endif

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -121,19 +121,19 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " sub sp, sp, #16\n"                           /* Create a stack frame to hold 3 parms + lr */
-    " str r4, [sp, #0]\n"                          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"                          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"                          /* Move parameter 6 (if any) into position */
-    " str lr, [sp, #12]\n"                         /* Save lr in the stack frame */
-    " ldr ip, =g_stublookup\n"                     /* R12=The base of the stub lookup table */
-    " ldr ip, [ip, r0, lsl #2]\n"                  /* R12=The address of the stub for this SYSCALL */
-    " blx ip\n"                                    /* Call the stub (modifies lr) */
-    " ldr lr, [sp, #12]\n"                         /* Restore lr */
-    " add sp, sp, #16\n"                           /* Destroy the stack frame */
-    " mov r2, r0\n"                                /* R2=Save return value in R2 */
-    " mov r0, " STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-    " svc " STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
+    " sub sp, sp, #16\n"                            /* Create a stack frame to hold 3 parms + lr */
+    " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+    " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+    " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+    " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this SYSCALL */
+    " blx ip\n"                                     /* Call the stub (modifies lr) */
+    " ldr lr, [sp, #12]\n"                          /* Restore lr */
+    " add sp, sp, #16\n"                            /* Destroy the stack frame */
+    " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -88,25 +88,25 @@ static void dispatch_syscall(void)
        *              = orig_SP - 20 - ((orig_SP - 20) & ~7)
        */
 
-      " mov ip, sp\n"                                /* Calculate (orig_SP - new_SP) */
+      " mov ip, sp\n"                                 /* Calculate (orig_SP - new_SP) */
       " sub ip, ip, #20\n"
       " and ip, ip, #7\n"
       " add ip, ip, #20\n"
       " sub sp, sp, ip\n"
-      " str r4, [sp, #0]\n"                          /* Move parameter 4 (if any) into position */
-      " str r5, [sp, #4]\n"                          /* Move parameter 5 (if any) into position */
-      " str r6, [sp, #8]\n"                          /* Move parameter 6 (if any) into position */
-      " str lr, [sp, #12]\n"                         /* Save lr in the stack frame */
-      " str ip, [sp, #16]\n"                         /* Save (orig_SP - new_SP) value */
-      " ldr ip, =g_stublookup\n"                     /* R12=The base of the stub lookup table */
-      " ldr ip, [ip, r0, lsl #2]\n"                  /* R12=The address of the stub for this syscall */
-      " blx ip\n"                                    /* Call the stub (modifies lr) */
-      " ldr lr, [sp, #12]\n"                         /* Restore lr */
-      " ldr r2, [sp, #16]\n"                         /* Restore (orig_SP - new_SP) value */
-      " add sp, sp, r2\n"                            /* Restore SP */
-      " mov r2, r0\n"                                /* R2=Save return value in R2 */
-      " mov r0, " STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-      " svc " STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
+      " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+      " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+      " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+      " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+      " str ip, [sp, #16]\n"                          /* Save (orig_SP - new_SP) value */
+      " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+      " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this syscall */
+      " blx ip\n"                                     /* Call the stub (modifies lr) */
+      " ldr lr, [sp, #12]\n"                          /* Restore lr */
+      " ldr r2, [sp, #16]\n"                          /* Restore (orig_SP - new_SP) value */
+      " add sp, sp, r2\n"                             /* Restore SP */
+      " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+      " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+      " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
     );
 }
 #endif

--- a/arch/arm/src/armv8-r/arm_syscall.c
+++ b/arch/arm/src/armv8-r/arm_syscall.c
@@ -121,19 +121,19 @@ static void dispatch_syscall(void)
 {
   __asm__ __volatile__
   (
-    " sub sp, sp, #16\n"                           /* Create a stack frame to hold 3 parms + lr */
-    " str r4, [sp, #0]\n"                          /* Move parameter 4 (if any) into position */
-    " str r5, [sp, #4]\n"                          /* Move parameter 5 (if any) into position */
-    " str r6, [sp, #8]\n"                          /* Move parameter 6 (if any) into position */
-    " str lr, [sp, #12]\n"                         /* Save lr in the stack frame */
-    " ldr ip, =g_stublookup\n"                     /* R12=The base of the stub lookup table */
-    " ldr ip, [ip, r0, lsl #2]\n"                  /* R12=The address of the stub for this SYSCALL */
-    " blx ip\n"                                    /* Call the stub (modifies lr) */
-    " ldr lr, [sp, #12]\n"                         /* Restore lr */
-    " add sp, sp, #16\n"                           /* Destroy the stack frame */
-    " mov r2, r0\n"                                /* R2=Save return value in R2 */
-    " mov r0, " STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
-    " svc " STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
+    " sub sp, sp, #16\n"                            /* Create a stack frame to hold 3 parms + lr */
+    " str r4, [sp, #0]\n"                           /* Move parameter 4 (if any) into position */
+    " str r5, [sp, #4]\n"                           /* Move parameter 5 (if any) into position */
+    " str r6, [sp, #8]\n"                           /* Move parameter 6 (if any) into position */
+    " str lr, [sp, #12]\n"                          /* Save lr in the stack frame */
+    " ldr ip, =g_stublookup\n"                      /* R12=The base of the stub lookup table */
+    " ldr ip, [ip, r0, lsl #2]\n"                   /* R12=The address of the stub for this SYSCALL */
+    " blx ip\n"                                     /* Call the stub (modifies lr) */
+    " ldr lr, [sp, #12]\n"                          /* Restore lr */
+    " add sp, sp, #16\n"                            /* Destroy the stack frame */
+    " mov r2, r0\n"                                 /* R2=Save return value in R2 */
+    " mov r0, #" STRINGIFY(SYS_syscall_return) "\n" /* R0=SYS_syscall_return */
+    " svc #" STRINGIFY(SYS_syscall) "\n"            /* Return from the SYSCALL */
   );
 }
 #endif


### PR DESCRIPTION
1. fix the naked_function inline asm expansion compile error with Greenhills compiler
2. fix the incorrect stub-function entry address of svc call