### PR TITLE
nuttx/arch: remove the custom board check in up_testset implementation

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -492,6 +492,7 @@ config ARCH_HAVE_TESTSET
 config ARCH_HAVE_CUSTOM_TESTSET
 	bool
 	default n
+	select ARCH_HAVE_TESTSET
 
 config ARCH_HAVE_THREAD_LOCAL
 	bool

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -489,6 +489,10 @@ config ARCH_HAVE_TESTSET
 	bool
 	default n
 
+config ARCH_HAVE_CUSTOM_TESTSET
+	bool
+	default n
+
 config ARCH_HAVE_THREAD_LOCAL
 	bool
 	default n

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -221,6 +221,7 @@ config ARCH_CHIP_LC823450
 	select ARCH_HAVE_HEAPCHECK
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_I2CRESET
+	select ARCH_HAVE_CUSTOM_TESTSET
 	select ARCH_HAVE_CUSTOM_VECTORS
 	---help---
 		ON Semiconductor LC823450 architectures (ARM dual Cortex-M3)
@@ -344,11 +345,11 @@ config ARCH_CHIP_RP2040
 	select ARCH_CORTEXM0
 	select ARCH_HAVE_RAMVECTORS
 	select ARCH_HAVE_MULTICPU
-	select ARCH_HAVE_TESTSET
 	select ARCH_HAVE_I2CRESET
 	select ARM_HAVE_WFE_SEV
 	select ARCH_HAVE_PWM_MULTICHAN
 	select ARCH_BOARD_COMMON
+	select ARCH_HAVE_CUSTOM_TESTSET
 	select ARCH_HAVE_CUSTOM_VECTORS
 	---help---
 		Raspberry Pi RP2040 architectures (ARM dual Cortex-M0+).
@@ -655,6 +656,7 @@ config ARCH_CHIP_CXD56XX
 	select ARCH_HAVE_SDIO if MMCSD
 	select ARCH_HAVE_MATH_H
 	select ARCH_HAVE_I2CRESET
+	select ARCH_HAVE_CUSTOM_TESTSET
 	select ARCH_HAVE_CUSTOM_VECTORS
 	---help---
 		Sony CXD56XX (ARM Cortex-M4) architectures

--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -114,10 +114,7 @@ typedef uint8_t spinlock_t;
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_HAVE_TESTSET) \
-    && !defined(CONFIG_ARCH_CHIP_LC823450) \
-    && !defined(CONFIG_ARCH_CHIP_CXD56XX) \
-    && !defined(CONFIG_ARCH_CHIP_RP2040)
+#if defined(CONFIG_ARCH_HAVE_TESTSET) && !defined(CONFIG_ARCH_HAVE_CUSTOM_TESTSET)
 static inline_function spinlock_t up_testset(volatile spinlock_t *lock)
 {
   spinlock_t ret = SP_UNLOCKED;


### PR DESCRIPTION
the up_testset implementation is common code, should not add custom board check