### PR TITLE
sim: add optee build support

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -435,6 +435,9 @@ ifneq ($(CONFIG_HOST_MACOS),y)
 	         -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' >nuttx.ld
 	$(Q) echo "__init_array_start = .; __init_array_end = .; __fini_array_start = .; __fini_array_end = .;" >>nuttx.ld
 endif
+ifeq ($(CONFIG_OPTEE_OS),y)
+	$(Q) sed -i 's/\*(.text.hot .text.hot.*)/KEEP(*(SORT(.scattered_array*)))\n    *(.text.hot .text.hot.*)/g' nuttx.ld
+endif
 ifeq ($(CONFIG_MM_KASAN_GLOBAL),y)
 	$(Q) sed -i 's/\s*\.interp\s*:\s*{\s*\*(\.interp)\s*}/  \
 	            .kasan.global : {KEEP(*(.data..LASAN0)) KEEP (*(.data.rel.local..LASAN0)) }\n  \

--- a/cmake/nuttx_generate_sim_ld.cmake
+++ b/cmake/nuttx_generate_sim_ld.cmake
@@ -53,6 +53,12 @@ file(
   DESTINATION ${CMAKE_BINARY_DIR}
   FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 
+if(CONFIG_OPTEE_OS)
+  set(SIM_LD_ADD_SCATTERED_ARRAY_SECTION
+      " 's/\*\(.text.hot .text.hot.*\)/KEEP\(*\(SORT\(.scattered_array*\)\)\)\\n    *\(.text.hot .text.hot.*\)/g' "
+  )
+endif()
+
 add_custom_command(
   OUTPUT nuttx.ld
   COMMAND
@@ -61,5 +67,6 @@ add_custom_command(
     || true
   COMMAND sh process_sim_ld_script.sh nuttx-orig.ld nuttx.ld
   COMMAND sed -i '/\\.data *:/i " ${CONFIG_SIM_CUSTOM_DATA_SECTION} " ' nuttx.ld
+  COMMAND sed -i " ${SIM_LD_ADD_SCATTERED_ARRAY_SECTION} " nuttx.ld
   COMMENT "Generating sim linker script nuttx.ld"
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
1. add .scattered_array section inside .text section
2. the ".scattered_array" section is required by optee_os, optee_os will uniformly place all the functions that need to be called during the system startup phase into the `.scattered_array` section. In order to enable optee_os to start up normally, we need to add this section to the linker script explicitly, otherwise the function that put into `.scattered_array` section will be optimized out during link procedure.
