### PR TITLE
vela: add ltp kernel testcases build support

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -130,6 +130,7 @@
 #define _POSIX_PIPE_BUF       512
 #define _POSIX_STREAM_MAX     16
 #define _POSIX_TZNAME_MAX     3
+#define _POSIX2_LINE_MAX      80
 
 #ifdef CONFIG_SMALL_MEMORY
 
@@ -202,6 +203,7 @@
 
 #define ARG_MAX        _POSIX_ARG_MAX
 #define CHILD_MAX      _POSIX_CHILD_MAX
+#define LINE_MAX       _POSIX2_LINE_MAX
 #define LINK_MAX       _POSIX_LINK_MAX
 #define MAX_CANON      _POSIX_MAX_CANON
 #define MAX_INPUT      _POSIX_MAX_INPUT

--- a/include/signal.h
+++ b/include/signal.h
@@ -410,7 +410,11 @@ struct sigaction
   } sa_u;
   sigset_t          sa_mask;
   int               sa_flags;
-  FAR void         *sa_user; /* Passed to siginfo.si_user (non-standard) */
+  union
+  {
+    CODE void (*sa_restorer)(void);
+    FAR void         *sa_user; /* Passed to siginfo.si_user (non-standard) */
+  };
 };
 
 /* Definitions that adjust the non-standard naming */

--- a/include/signal.h
+++ b/include/signal.h
@@ -172,6 +172,8 @@
 
 #define SIGSYS          31
 
+#define SIGIOT          SIGABRT
+
 /* sigprocmask() "how" definitions.
  * Only one of the following can be specified:
  */
@@ -430,6 +432,8 @@ typedef struct
   int ss_flags;
   size_t ss_size;
 } stack_t;
+
+typedef CODE void (*sig_t)(int);
 
 /****************************************************************************
  * Public Function Prototypes

--- a/include/sys/fcntl.h
+++ b/include/sys/fcntl.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * include/sys/fcntl.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_FCNTL_H
+#define __INCLUDE_SYS_FCNTL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <fcntl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* __INCLUDE_SYS_FCNTL_H */

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -39,7 +39,16 @@
 
 /* Mount flags */
 
-#define MS_RDONLY 1 /* Mount file system read-only */
+#define MS_RDONLY       1    /* Mount file system read-only */
+#define MS_NOSUID       2    /* Ignore suid and sgid bits */
+#define MS_NODEV        4    /* Disallow access to device special files */
+#define MS_NOEXEC       8    /* Disallow program execution */
+#define MS_SYNCHRONOUS  16   /* Writes are synced at once */
+#define MS_REMOUNT      32   /* Alter flags of a mounted FS */
+#define MS_MANDLOCK     64   /* Allow mandatory locks on an FS */
+#define MS_DIRSYNC      128  /* Directory modifications are synchronous */
+#define MS_NOSYMFOLLOW  256  /* Do not follow symlinks */
+#define MS_NOATIME      1024 /* Do not update access times. */
 
 /* Un-mount flags
  *

--- a/include/sys/prctl.h
+++ b/include/sys/prctl.h
@@ -76,6 +76,9 @@
 #define PR_SET_NAME_EXT 3
 #define PR_GET_NAME_EXT 4
 
+#define PR_SET_DUMPABLE 5
+#define PR_GET_DUMPABLE 6
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -60,6 +60,7 @@
 #define RLIMIT_STACK    6           /* Limit on stack size */
 #define RLIMIT_AS       7           /* Limit on address space size */
 #define RLIMIT_MEMLOCK  8           /* Limit on memory use */
+#define RLIMIT_NICE     10          /* Limit on nice level */
 
 /* Below are not implemented yet: */
 

--- a/include/sys/sem.h
+++ b/include/sys/sem.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * include/sys/sem.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_SEM_H
+#define __INCLUDE_SYS_SEM_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* __INCLUDE_SYS_SEM_H */

--- a/include/sys/signal.h
+++ b/include/sys/signal.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * include/sys/signal.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_SIGNAL_H
+#define __INCLUDE_SYS_SIGNAL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <signal.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* __INCLUDE_SYS_VFS_H */

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -242,6 +242,8 @@
 #define SOL_SCO         17 /* See options in include/netpacket/bluetooth.h */
 #define SOL_RFCOMM      18 /* See options in include/netpacket/bluetooth.h */
 
+#define SOL_PACKET      19
+
 /* Protocol-level socket options may begin with this value */
 
 #define __SO_PROTOCOL  16

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -232,6 +232,8 @@ typedef int32_t      off_t;
 typedef int32_t      fpos_t;
 #endif
 
+typedef off_t        loff_t;
+
 /* blksize_t is a signed integer value used for file block sizes */
 
 typedef int16_t      blksize_t;

--- a/include/wait.h
+++ b/include/wait.h
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * include/wait.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_WAIT_H
+#define __INCLUDE_WAIT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/wait.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* __INCLUDE_WAIT_H */


### PR DESCRIPTION
1. add PR_SET_DUMPABLE flag
2. add mount flag definition
3. add LINE_MAX limits definition
4. add sys/sem.h header file
5. add loff_t data type definition
6. add wait.h header file
7. add sys/fcntl.h header file
8. add include/sys/signal.h to the signal
9. add SOL_PACKET packet operation type definition
10. add RLIMIT_NICE consntant definition
11. add sa_restorer to struct sigaction