### PR TITLE
netconfig.h:modify netconfig to support communicating in slave core

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -88,12 +88,14 @@
 #  define HAVE_INET_SOCKETS
 
 #  if (defined(CONFIG_NET_IPv4) && (defined(NET_UDP_HAVE_STACK) || \
-       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMP_SOCKET)
+       defined(NET_TCP_HAVE_STACK) || defined(CONFIG_NET_USRSOCK))) || \
+       defined(CONFIG_NET_ICMP_SOCKET)
 #    define HAVE_PFINET_SOCKETS
 #  endif
 
 #  if (defined(CONFIG_NET_IPv6) && (defined(NET_UDP_HAVE_STACK) || \
-       defined(NET_TCP_HAVE_STACK))) || defined(CONFIG_NET_ICMPv6_SOCKET)
+       defined(NET_TCP_HAVE_STACK) || defined(CONFIG_NET_USRSOCK))) || \
+       defined(CONFIG_NET_ICMPv6_SOCKET)
 #    define HAVE_PFINET6_SOCKETS
 #  endif
 #endif


### PR DESCRIPTION
### Summary
Add CONFIG_NET_USRSOCK & CONFIG_NET_IPv4 & CONFIG_NET_IPv6 to support communicating in slave core

### Impact
communicating in slave core

### Testing
Manual verification