### PR TITLE
isrthread: add configuring the stack of an isrthread as static

### DIFF
--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -349,6 +349,7 @@ int work_usrstart(void);
  * Input Parameters:
  *   name       - Name of the new task
  *   priority   - Priority of the new task
+ *   stack_addr - Stack buffer of the new task
  *   stack_size - size (in bytes) of the stack needed
  *   nthreads   - Number of work thread should be created
  *
@@ -359,6 +360,7 @@ int work_usrstart(void);
 
 FAR struct kwork_wqueue_s *work_queue_create(FAR const char *name,
                                              int priority,
+                                             FAR void *stack_addr,
                                              int stack_size, int nthreads);
 
 /****************************************************************************

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -346,6 +346,11 @@ config IRQ_NWORKS
 	---help---
 		The max num of active irq wqueue.
 
+config IRQ_WORK_SECTION
+	string "The section where irq stack is located"
+	---help---
+		The section where irq stack is located.
+
 config IRQ_WORK_STACKSIZE
 	int "The default stack size for isr wqueue"
 	default DEFAULT_TASK_STACKSIZE

--- a/sched/irq/CMakeLists.txt
+++ b/sched/irq/CMakeLists.txt
@@ -42,4 +42,9 @@ if(CONFIG_IRQCHAIN)
   list(APPEND SRCS irq_chain.c)
 endif()
 
+if(CONFIG_IRQ_WORK_SECTION)
+  target_compile_definitions(
+    sched PRIVATE -DIRQ_WORK_SECTION="${CONFIG_IRQ_WORK_SECTION}")
+endif()
+
 target_sources(sched PRIVATE ${SRCS})

--- a/sched/irq/Make.defs
+++ b/sched/irq/Make.defs
@@ -42,6 +42,10 @@ ifeq ($(CONFIG_IRQCHAIN),y)
 CSRCS += irq_chain.c
 endif
 
+ifneq ($(CONFIG_IRQ_WORK_SECTION),"")
+  CFLAGS += ${DEFINE_PREFIX}IRQ_WORK_SECTION=CONFIG_IRQ_WORK_SECTION
+endif
+
 # Include irq build support
 
 DEPPATH += --dep-path irq

--- a/sched/irq/irq_attach_wqueue.c
+++ b/sched/irq/irq_attach_wqueue.c
@@ -71,6 +71,14 @@ static struct irq_work_info_s g_irq_work_vector[NR_IRQS];
 static mutex_t g_irq_wqueue_lock = NXMUTEX_INITIALIZER;
 static FAR struct kwork_wqueue_s *g_irq_wqueue[CONFIG_IRQ_NWORKS];
 
+#ifdef IRQ_WORK_SECTION
+static uint8_t g_irq_work_stack[CONFIG_IRQ_NWORKS][CONFIG_IRQ_WORK_STACKSIZE]
+locate_data(IRQ_WORK_SECTION);
+#else
+static uint8_t g_irq_work_stack[CONFIG_IRQ_NWORKS]
+                               [CONFIG_IRQ_WORK_STACKSIZE];
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -98,7 +106,7 @@ inline_function FAR struct kwork_wqueue_s *irq_get_wqueue(int priority)
 
   DEBUGASSERT(i < CONFIG_IRQ_NWORKS);
 
-  queue = work_queue_create("isrwork", priority,
+  queue = work_queue_create("isrwork", priority, g_irq_work_stack[i],
                             CONFIG_IRQ_WORK_STACKSIZE, 1);
 
   g_irq_wqueue[i] = queue;

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -230,6 +230,7 @@ static int work_thread(int argc, FAR char *argv[])
  * Input Parameters:
  *   name       - Name of the new task
  *   priority   - Priority of the new task
+ *   stack_addr - Stack buffer of the new task
  *   stack_size - size (in bytes) of the stack needed
  *   wqueue     - Work queue instance
  *
@@ -239,7 +240,7 @@ static int work_thread(int argc, FAR char *argv[])
  ****************************************************************************/
 
 static int work_thread_create(FAR const char *name, int priority,
-                              int stack_size,
+                              FAR void *stack_addr, int stack_size,
                               FAR struct kwork_wqueue_s *wqueue)
 {
   FAR char *argv[3];
@@ -264,8 +265,8 @@ static int work_thread_create(FAR const char *name, int priority,
       argv[1] = arg1;
       argv[2] = NULL;
 
-      pid = kthread_create(name, priority, stack_size,
-                           work_thread, argv);
+      pid = kthread_create_with_stack(name, priority, stack_addr, stack_size,
+                                      work_thread, argv);
 
       DEBUGASSERT(pid > 0);
       if (pid < 0)
@@ -299,8 +300,9 @@ static int work_thread_create(FAR const char *name, int priority,
  * Input Parameters:
  *   name       - Name of the new task
  *   priority   - Priority of the new task
+ *   stack_addr - Stack buffer of the new task
  *   stack_size - size (in bytes) of the stack needed
- *   nthreads    - Number of work thread should be created
+ *   nthreads   - Number of work thread should be created
  *
  * Returned Value:
  *   The work queue handle returned on success.  Otherwise, NULL
@@ -309,6 +311,7 @@ static int work_thread_create(FAR const char *name, int priority,
 
 FAR struct kwork_wqueue_s *work_queue_create(FAR const char *name,
                                              int priority,
+                                             FAR void *stack_addr,
                                              int stack_size, int nthreads)
 {
   FAR struct kwork_wqueue_s *wqueue;
@@ -337,7 +340,7 @@ FAR struct kwork_wqueue_s *work_queue_create(FAR const char *name,
 
   /* Create the work queue thread pool */
 
-  ret = work_thread_create(name, priority, stack_size, wqueue);
+  ret = work_thread_create(name, priority, stack_addr, stack_size, wqueue);
   if (ret < 0)
     {
       kmm_free(wqueue);
@@ -457,7 +460,7 @@ int work_start_highpri(void)
 
   sinfo("Starting high-priority kernel worker thread(s)\n");
 
-  return work_thread_create(HPWORKNAME, CONFIG_SCHED_HPWORKPRIORITY,
+  return work_thread_create(HPWORKNAME, CONFIG_SCHED_HPWORKPRIORITY, NULL,
                             CONFIG_SCHED_HPWORKSTACKSIZE,
                             (FAR struct kwork_wqueue_s *)&g_hpwork);
 }
@@ -485,7 +488,7 @@ int work_start_lowpri(void)
 
   sinfo("Starting low-priority kernel worker thread(s)\n");
 
-  return work_thread_create(LPWORKNAME, CONFIG_SCHED_LPWORKPRIORITY,
+  return work_thread_create(LPWORKNAME, CONFIG_SCHED_LPWORKPRIORITY, NULL,
                             CONFIG_SCHED_LPWORKSTACKSIZE,
                             (FAR struct kwork_wqueue_s *)&g_lpwork);
 }


### PR DESCRIPTION
## Summary
isrthread: add configuring the stack of an isrthread as static

reason:
we configure the isr thread stack as static to allow for more flexible placement of the stack.

## Impact
isrthread 


https://github.com/apache/nuttx/pull/14686
https://github.com/apache/nuttx-apps/pull/2828
These two pull requests (PRs) must be merged together.
## Testing
ci ostest
