### PR TITLE
goldfish: use arch_idle_custom

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -693,6 +693,7 @@ config ARCH_CHIP_GOLDFISH_ARM
 	select ARCH_HAVE_RESET
 	select ARM_HAVE_PSCI
 	select ARM_HAVE_NEON
+	select ARCH_IDLE_CUSTOM
 	---help---
 		GOLDFISH virt platform (ARMv7a)
 

--- a/arch/arm/src/goldfish/CMakeLists.txt
+++ b/arch/arm/src/goldfish/CMakeLists.txt
@@ -24,4 +24,8 @@ if(CONFIG_SMP)
   list(APPEND SRCS goldfish_cpuboot.c)
 endif()
 
+if(CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS goldfish_idle.c)
+endif()
+
 target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/goldfish/Make.defs
+++ b/arch/arm/src/goldfish/Make.defs
@@ -28,3 +28,7 @@ CHIP_CSRCS += goldfish_memorymap.c goldfish_serial.c goldfish_timer.c
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += goldfish_cpuboot.c
 endif
+
+ifeq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
+CHIP_CSRCS += goldfish_idle.c
+endif

--- a/arch/arm/src/goldfish/goldfish_idle.c
+++ b/arch/arm/src/goldfish/goldfish_idle.c
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * arch/arm/src/goldfish/goldfish_idle.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_idle
+ *
+ * Description:
+ *   up_idle() is the logic that will be executed when there is no other
+ *   ready-to-run task.  This is processor idle time and will continue until
+ *   some interrupt occurs to cause a context switch from the idle task.
+ *
+ *   Processing in this state may be processor-specific. e.g., this is where
+ *   power management operations might be performed.
+ *
+ ****************************************************************************/
+
+void up_idle(void)
+{
+#if defined(CONFIG_SUPPRESS_INTERRUPTS) || defined(CONFIG_SUPPRESS_TIMER_INTS)
+  /* If the system is idle and there are no timer interrupts, then process
+   * "fake" timer interrupts. Hopefully, something will wake up.
+   */
+
+  nxsched_process_timer();
+#else
+
+  /* Sleep until an interrupt occurs to save power */
+
+  asm("WFI");
+#endif
+}


### PR DESCRIPTION
Will benifit on cpuload, and power consume

before patch:

goldfish use default arm_common/idle.c, no WFI, always busy loop on idle, cost lots of PC battery.

after patch:

will use a goldfish custom idle, save power consume on emulator arm-v7a
