### PR TITLE
sim(CMake):support sim elf and dynamic libs package in post build

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -323,3 +323,16 @@ else ifeq ($(CONFIG_HOST_MACOS),)
   ARCHPICFLAGS += -no-pie
   LDFLAGS += -Wl,-no-pie
 endif
+
+define POSTBUILD
+	$(Q)echo "Pac SIM with dynamic libs..";
+	@ rm -rf sim-pac;
+	@ mkdir -p sim-pac/libs;
+	@ cp nuttx sim-pac/nuttx;
+	@ ldd sim-pac/nuttx | grep "=> /" | awk '{print $$3}' | xargs -I '{}' cp -v '{}' sim-pac/libs;
+	@ readelf -l nuttx | grep "program interpreter" | awk -F':' '{print $$2}'| cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac;
+	@ cp $(TOPDIR)/tools/simlaunch.sh sim-pac;
+	@ tar -czf nuttx.tgz sim-pac;
+	$(Q)echo "SIM elf with dynamic libs archive in nuttx.tgz"
+	@ rm -rf sim-pac;
+endef

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -324,15 +324,17 @@ else ifeq ($(CONFIG_HOST_MACOS),)
   LDFLAGS += -Wl,-no-pie
 endif
 
-define POSTBUILD
-	$(Q)echo "Pac SIM with dynamic libs..";
-	@ rm -rf sim-pac;
-	@ mkdir -p sim-pac/libs;
-	@ cp nuttx sim-pac/nuttx;
-	@ ldd sim-pac/nuttx | grep "=> /" | awk '{print $$3}' | xargs -I '{}' cp -v '{}' sim-pac/libs;
-	@ readelf -l nuttx | grep "program interpreter" | awk -F':' '{print $$2}'| cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac;
-	@ cp $(TOPDIR)/tools/simlaunch.sh sim-pac;
-	@ tar -czf nuttx.tgz sim-pac;
-	$(Q)echo "SIM elf with dynamic libs archive in nuttx.tgz"
-	@ rm -rf sim-pac;
-endef
+ifeq ($(CONFIG_HOST_LINUX),y)
+  define POSTBUILD
+  	$(Q)echo "Pac SIM with dynamic libs..";
+  	@ rm -rf sim-pac;
+  	@ mkdir -p sim-pac/libs;
+  	@ cp nuttx sim-pac/nuttx;
+  	@ ldd sim-pac/nuttx | grep "=> /" | awk '{print $$3}' | xargs -I '{}' cp -v '{}' sim-pac/libs;
+  	@ readelf -l nuttx | grep "program interpreter" | awk -F':' '{print $$2}'| cut -d"]" -f1 | xargs -I '{}' cp -v '{}' sim-pac;
+  	@ cp $(TOPDIR)/tools/simlaunch.sh sim-pac;
+  	@ tar -czf nuttx.tgz sim-pac;
+  	$(Q)echo "SIM elf with dynamic libs archive in nuttx.tgz"
+  	@ rm -rf sim-pac;
+  endef
+endif


### PR DESCRIPTION
## Summary

    use the dynamic library .so of the binding compilation environment,
    and then modify the dynamic loader of elf at runtime to run sim elf across system versions

    1.add post-build for sim build
    2.collect dynamic .so and dynamic interpreter
    3.add execution script for the entire package sim elf

    change text-segment to 0x50000000
    because patchelf will modify the .dynamic section in elf,
    the upward alignment of elf will be less than 0x3fffffff,
    which will cause asan shadow memory overlap error

## Impact

bugfix
    avoid SIM compilation post build issues on other platforms

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela --cmake 

```


