### PR TITLE
cmake(enhance):Enhance romfs so that RAWS files can be added in any location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,8 +582,10 @@ if(NOT CONFIG_BUILD_KERNEL)
 
 endif()
 
-# after we traverse all build directories unify all target dependencies
+# after we traverse all build directories unify all target dependencies and all
+# romfs target
 process_all_target_dependencies()
+process_all_directory_romfs()
 
 # Link step ##################################################################
 

--- a/cmake/nuttx_add_romfs.cmake
+++ b/cmake/nuttx_add_romfs.cmake
@@ -340,12 +340,18 @@ function(process_all_directory_romfs)
         DEPENDS ${dyn_deps})
       list(APPEND DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX})
     else()
+      list(FIND DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX} index)
+      if(index GREATER -1)
+        set(APPEND_OPTION APPEND)
+      else()
+        set(APPEND_OPTION)
+      endif()
       list(APPEND DEPENDS ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX})
       add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX}
         COMMAND
           ${CMAKE_COMMAND} -E copy ${SOURCE_ETC_PREFIX}/${SOURCE_ETC_SUFFIX}
-          ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX}
+          ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX} ${APPEND_OPTION}
         DEPENDS ${dyn_deps})
       list(APPEND DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_ETC_SUFFIX})
     endif()


### PR DESCRIPTION
## Summary

1.make the generation sequence of etc romfs no longer bound to the board 2.RCRAWS RCSRCS can be added from any directory
3.enable dynamic files, files generated during the compilation process,
    and ensure the correct time order

## Impact

new feat

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela --cmake 

```


