### PR TITLE
build(bugfix):tools/Make.defs reads the APPS DIR relative path and corrects it to an absolute path

### DIFF
--- a/tools/Make.defs
+++ b/tools/Make.defs
@@ -29,6 +29,9 @@
 ifeq ($(CONFIG_APPS_DIR),)
 CONFIG_APPS_DIR = $(TOPDIR)/../apps
 endif
+ifneq ($(firstword $(CONFIG_APPS_DIR)),/)
+CONFIG_APPS_DIR := $(TOPDIR)/$(CONFIG_APPS_DIR)
+endif
 APPDIR := $(realpath ${shell if [ -r $(CONFIG_APPS_DIR)/Makefile ]; then echo "$(CONFIG_APPS_DIR)"; fi})
 
 ifeq ($(APPDIR),)


### PR DESCRIPTION
## Summary

The location of calling tools/Make.defs is no longer under TOPDIR. When CONFIG_APPS_DIR is set to a relative path.
APPS's Make.defs will not be correctly imported.

We correct the relative path to the absolute path of TOPDIR

## Impact

bugfix

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela --cmake 

```


