### PR TITLE
video/fb: fix integer overflow issue

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -1726,7 +1726,7 @@ int fb_register_device(int display, int plane,
   char devname[16];
   int nplanes;
   int ret;
-  size_t i;
+  ssize_t i;
 
   /* Allocate a framebuffer state instance */
 


### PR DESCRIPTION
Use `ssize_t` type to preserve signedness.