### PR TITLE
golfish_gpu_fb: clear fb when initialization

### DIFF
--- a/drivers/video/goldfish_gpu_fb.c
+++ b/drivers/video/goldfish_gpu_fb.c
@@ -563,6 +563,10 @@ int goldfish_gpu_fb_register(int display)
   fb->vtable.getplaneinfo = goldfish_gpu_fb_getplaneinfo;
   fb->vtable.getvideoinfo = goldfish_gpu_fb_getvideoinfo;
 
+  /* Clear goldfish_gpu_fb */
+
+  goldfish_gpu_fb_commit(fb, fb->planeinfo.fbmem);
+
   /* Create the vsync thread */
 
   snprintf(arg1, 32, "%p", fb);


### PR DESCRIPTION
it's better to clear FB when initialization avoiding the influence of the initial content of the FB.