### PR TITLE
Unify the linking options for 32-bit and 64-bit to text-segment=0x300…

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -289,10 +289,7 @@ ifeq ($(CONFIG_HOST_MACOS),y)
   LDFLAGS += -Wl,-dead_strip
 else
   LDFLAGS += -Wl,--gc-sections
-
-  # Let the symbol table link from 0x50000000
-  # which is more convenient for debugging.
-  LDFLAGS += -Wl,-Ttext-segment=0x50000000
+  LDFLAGS += -Wl,-Ttext-segment=0x40000000
 endif
 
 ifeq ($(CONFIG_DEBUG_LINK_MAP),y)


### PR DESCRIPTION
…00000.