### PR TITLE
xtensa: fix up_enable_dcache

### DIFF
--- a/arch/xtensa/src/common/xtensa_cache.c
+++ b/arch/xtensa/src/common/xtensa_cache.c
@@ -348,12 +348,10 @@ void up_enable_dcache(void)
 
   /* Check if the D-Cache is enabled */
 
-  if ((memctl & MEMCTL_INV_EN) != 0)
+  if ((memctl & (MEMCTL_DCWA_MASK | MEMCTL_DCWU_MASK)) != 0)
     {
       return;
     }
-
-  up_invalidate_dcache_all();
 
   /* set ways allocatable & ways use */
 


### PR DESCRIPTION
1. use correct flag to judge whether dcache is enabled;
2. set `MEMCTL_INV_EN` bit has the meaning to invalidate, so there is no need to invalidate seperately.