### PR TITLE
if the nameserver is existing, only return not need do dns_notify_nameserver

### DIFF
--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -227,7 +227,9 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
           ret = OK;
         }
 
-      goto errout;
+      dns_unlock();
+      fclose(stream);
+      return ret;
     }
 
 #if CONFIG_NETDB_DNSSERVER_NAMESERVERS > 1


### PR DESCRIPTION
### Summary
when dns nameserver is existing, not need do dns_notify_nameserver

### Impact
N/A

### Testing
The main impact is on DNS resolution.