### PR TITLE
[BUG-FIX] There is a bug in the rw_spinlock.

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -929,11 +929,15 @@ static inline_function void read_unlock(FAR volatile rwlock_t *lock)
 
 static inline_function void write_lock(FAR volatile rwlock_t *lock)
 {
-  int zero = RW_SP_UNLOCKED;
-
-  while (!atomic_compare_exchange_strong((FAR atomic_int *)lock,
-                                         &zero, RW_SP_WRITE_LOCKED))
+  while (true)
     {
+      int zero = RW_SP_UNLOCKED;
+      if (atomic_compare_exchange_strong((FAR atomic_int *)lock,
+                                         &zero, RW_SP_WRITE_LOCKED))
+        {
+          break;
+        }
+
       SP_DSB();
       SP_WFE();
     }


### PR DESCRIPTION
There is a bug in the rw_spinlock. Each time atomic_compare_exchange_strong(object, expected, desired) is executed, the value of object is assigned to expected, so the value of expected needs to be reset each time.