### PR TITLE
drivers/sensors/gnss: Fix deactivate failure when using both topic and device

### DIFF
--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -176,10 +176,11 @@ static int gnss_activate(FAR struct sensor_lowerhalf_s *lower,
   if ((upper->crefs == 0 && enable) || (upper->crefs == 1 && !enable))
     {
       ret = upper->lower->ops->activate(upper->lower, filep, enable);
-      if (ret >= 0)
-        {
-          upper->crefs += enable ? 1 : -1;
-        }
+    }
+
+  if (ret >= 0)
+    {
+      upper->crefs += enable ? 1 : -1;
     }
 
   nxmutex_unlock(&upper->lock);


### PR DESCRIPTION
## Summary
drivers/sensors/gnss: Fix deactivate failure when using both topic and device
Deactivate lower driver fails when both uORB topic and driver device are subscribed and opened. (crefs has increased to 2)

## Impact
drivers/sensors/gnss:

## Testing
1. Selftest with customized board.
2. CI