### PR TITLE
sched: add some DEBUGASSERT when nxsched_release_tcb()

### DIFF
--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -107,6 +107,10 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
 
   if (tcb)
     {
+      /* Released tcb shouldn't on any list */
+
+      DEBUGASSERT(tcb->flink == NULL && tcb->blink == NULL);
+
 #ifndef CONFIG_DISABLE_POSIX_TIMERS
       /* Release any timers that the task might hold.  We do this
        * before release the PID because it may still be trying to


### PR DESCRIPTION
## Summary

sched: add some DEBUGASSERT when nxsched_release_tcb()

## Impact

nxsched_release_tcb

## Testing

CI

