### PR TITLE
rammtd:add rammtd_uninitialize

### DIFF
--- a/drivers/mtd/rammtd.c
+++ b/drivers/mtd/rammtd.c
@@ -518,3 +518,21 @@ FAR struct mtd_dev_s *rammtd_initialize(FAR uint8_t *start, size_t size)
 
   return &priv->mtd;
 }
+
+/****************************************************************************
+ * Name: rammtd_uninitialize
+ *
+ * Description:
+ *   Free the resources associated with a RAM MTD device instance.
+ *
+ * Input Parameters:
+ *   dev - Pointer to the MTD device instance to be uninitialized.
+ *
+ ****************************************************************************/
+
+void rammtd_uninitialize(FAR struct mtd_dev_s *dev)
+{
+  FAR struct ram_dev_s *priv = (FAR struct ram_dev_s *)dev;
+
+  kmm_free(priv);
+}

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -491,6 +491,19 @@ FAR struct mtd_dev_s *mx35_initialize(FAR struct spi_dev_s *dev);
 FAR struct mtd_dev_s *rammtd_initialize(FAR uint8_t *start, size_t size);
 
 /****************************************************************************
+ * Name: rammtd_uninitialize
+ *
+ * Description:
+ *   Free the resources associated with a RAM MTD device instance.
+ *
+ * Input Parameters:
+ *   dev - Pointer to the MTD device instance to be uninitialized.
+ *
+ ****************************************************************************/
+
+void rammtd_uninitialize(FAR struct mtd_dev_s *dev);
+
+/****************************************************************************
  * Name: ramtron_initialize
  *
  * Description:


### PR DESCRIPTION
## Summary
  Added rammtd_uninitialize to manage rammtd.
  In some scenarios, when we no longer need rammtd, we can destruct it to save memory.

## Impact
  A destructor is introduced in the public interface of rammtd/

## Testing
  Test in sim / qemu / actual device project.
  It can deinitialize the specified rammtd.
