### PR TITLE
fs:replase all asprintf / strdup in fs with fs_heap_xxx

### DIFF
--- a/fs/yaffs/yaffs_vfs.c
+++ b/fs/yaffs/yaffs_vfs.c
@@ -1114,7 +1114,7 @@ static int yaffs_vfs_bind(FAR struct inode *driver, FAR const void *data,
   dev->driver_context = mtd;
 
   p = &dev->param;
-  p->name = strdup(mtd->name);
+  p->name = fs_heap_strdup(mtd->name);
   if (p->name == NULL)
     {
       ret = -ENOMEM;
@@ -1195,7 +1195,7 @@ static int yaffs_vfs_bind(FAR struct inode *driver, FAR const void *data,
   return OK;
 
 errout_with_name:
-  lib_free((FAR void *)(p->name));
+  fs_heap_free((FAR void *)(p->name));
   yaffs_remove_device(dev);
 errout_with_dev:
   fs_heap_free(dev);
@@ -1232,7 +1232,7 @@ static int yaffs_vfs_unbind(FAR void *handle, FAR struct inode **driver,
       /* Remove and release dev */
 
       yaffs_remove_device(dev);
-      lib_free((FAR void *)(dev->param.name));
+      fs_heap_free((FAR void *)(dev->param.name));
       fs_heap_free(dev);
 
       /* We hold a reference to the driver but should not but


### PR DESCRIPTION
## Summary
  Replace strdup / asprintf in yaffs_vfs with fs_heap_strdup / fs_heap_asprintf.
  By default, fs_heap_xxx is equivalent to kmm_xxx. When a specified segment is provided, fs_heap_xxx will request memory from the specified segment. This is used to separate the overall file system and kernel memory.

## Impact
  Replace strdup / asprintf in yaffs_vfs with fs_heap_strdup / fs_heap_asprintf

## Testing
  Test in sim / qemu / actual device project.
  Yaffs working properly
