### PR TITLE
libc/machine/CMakeLists: should alaways build arch_atomic.c

### DIFF
--- a/libs/libc/machine/CMakeLists.txt
+++ b/libs/libc/machine/CMakeLists.txt
@@ -22,9 +22,7 @@
 
 add_subdirectory(${CONFIG_ARCH})
 
-if(CONFIG_LIBC_ARCH_ATOMIC)
-  target_sources(c PRIVATE arch_atomic.c)
-endif()
+target_sources(c PRIVATE arch_atomic.c)
 
 if(CONFIG_MM_KASAN)
   target_sources(c PRIVATE arch_libc.c)


### PR DESCRIPTION
## Summary
  The purpose of this PR is to fix the problem that in CMake Build, if Basic Atomic is used, the relevant atomic implementation is missing.We have removed the CONFIG_LIBC_ARCH_ATOMIC macro, so arch_atomic.c should always be compiled.

## Impact
  Removed dependency on arch_atomic.c in cmakelist.txt

## Testing
  Test in qemu / actual device project.
  When Basic Atomic + CMake is compiled, this can be compiled through.


