### PR TITLE
lib_pathbuffer:change ffs to ffsl

### DIFF
--- a/libs/libc/misc/lib_pathbuffer.c
+++ b/libs/libc/misc/lib_pathbuffer.c
@@ -41,8 +41,8 @@
 
 struct pathbuffer_s
 {
-  mutex_t lock;             /* Lock for the buffer */
-  unsigned int free_bitmap; /* Bitmap of free buffer */
+  mutex_t lock;              /* Lock for the buffer */
+  unsigned long free_bitmap; /* Bitmap of free buffer */
   char buffer[CONFIG_LIBC_MAX_PATHBUFFER][PATH_MAX];
 };
 
@@ -87,7 +87,7 @@ FAR char *lib_get_pathbuffer(void)
   /* Try to find a free buffer */
 
   nxmutex_lock(&g_pathbuffer.lock);
-  index = ffs(g_pathbuffer.free_bitmap) - 1;
+  index = ffsl(g_pathbuffer.free_bitmap) - 1;
   if (index >= 0 && index < CONFIG_LIBC_MAX_PATHBUFFER)
     {
       g_pathbuffer.free_bitmap &= ~(1u << index);


### PR DESCRIPTION
## Summary
  fix build error
```
riscv-none-elf-ld: /github/workspace/sources/nuttx/staging/libc.a(lib_pathbuffer.o): in function `lib_get_pathbuffer': /github/workspace/sources/nuttx/libs/libc/misc/lib_pathbuffer.c:89:(.text.lib_get_pathbuffer+0x1c): undefined reference to `ffs' make[1]: *** [Makefile:189: nuttx] Error 1
make: *** [tools/Unix.mk:551: nuttx] Error 2
```

## Impact
Modified ffs->ffsl in lib_pathbuffer.c

## Testing
Test in sim / qemu / actual device project.
Their final results are consistent.

