### PR TITLE
fs_automount:fix ci break

### DIFF
--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -813,7 +813,7 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
   FAR char *devpath = lib_get_pathbuffer();
   if (devpath == NULL)
     {
-      return;
+      return NULL;
     }
 #endif /* CONFIG_FS_AUTOMOUNTER_DRIVER */
 
@@ -826,6 +826,9 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");
+#ifdef CONFIG_FS_AUTOMOUNTER_DRIVER
+      lib_put_pathbuffer(devpath);
+#endif /* CONFIG_FS_AUTOMOUNTER_DRIVER */
       return NULL;
     }
 


### PR DESCRIPTION
## Summary
  fix build warning
```
==================================================================================== Configuration/Tool: spresense/example_camera,CONFIG_ARM_TOOLCHAIN_GNU_EABI 2024-11-12 12:24:37
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
mount/fs_automount.c: In function 'automount_initialize': Error: mount/fs_automount.c:816:7: error: 'return' with no value, in function returning non-void [-Werror=return-type]
  816 |       return;
      |       ^~~~~~
In file included from mount/fs_automount.c:43:
/github/workspace/sources/nuttx/include/nuttx/fs/automount.h:176:11: note: declared here
  176 | FAR void *automount_initialize(FAR const struct automount_lower_s *lower);
      |           ^~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

## Impact
  Optimized fs_autoformat.c code logic


## Testing
  Test in qemu / actual device project.
  It can build success without warning.

