### PR TITLE
v9fs fix

### DIFF
--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1098,13 +1098,13 @@ ssize_t v9fs_client_write(FAR struct v9fs_client_s *client, uint32_t fid,
 
   while (buflen > 0)
     {
+      request.count = buflen > fidp->iounit ? fidp->iounit : buflen;
       request.header.size = V9FS_HDRSZ + V9FS_BIT32SZ + V9FS_BIT64SZ +
                             V9FS_BIT32SZ + request.count;
       request.header.type = V9FS_TWRITE;
       request.header.tag = v9fs_get_tagid(client);
       request.fid = fid;
       request.offset = offset;
-      request.count = buflen > fidp->iounit ? fidp->iounit : buflen;
 
       wiov[0].iov_base = &request;
       wiov[0].iov_len = V9FS_HDRSZ + V9FS_BIT32SZ + V9FS_BIT64SZ +

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -173,7 +173,7 @@ begin_packed_struct struct v9fs_attach_s
 {
   struct v9fs_header_s header;
   uint32_t fid;
-  uint16_t afid;
+  uint32_t afid;
   uint8_t buffer[2 * (V9FS_BIT16SZ + NAME_MAX) + V9FS_BIT32SZ];
 } end_packed_struct;
 

--- a/fs/v9fs/client.c
+++ b/fs/v9fs/client.c
@@ -1589,6 +1589,16 @@ int v9fs_client_walk(FAR struct v9fs_client_s *client, FAR const char *path,
       newfid = ret;
     }
 
+  /* There are differences in different server implementations, so it is
+   * necessary to check whether the returned nwqid satisfies the requested
+   * number.
+   */
+
+  if (response.nwqid != nwname)
+    {
+      newfid = -ENOENT;
+    }
+
 err:
   lib_put_pathbuffer(request_payload);
   lib_put_pathbuffer(response_payload);


### PR DESCRIPTION
## Summary
This PR brings many fixes related to the stability of v9fs.
- Optimize the content of protocol packets sent
- Compatibility check for different types of server implementations
- Unify the interface return type

## Impact
There is no difference in usage. This PR aims to improve the stability of v9fs.

## Testing
Test in Qemu.
It ensures the stability of v9fs work, and the fs test cases pass.
