### PR TITLE
fix build failed after fs header add api.

### DIFF
--- a/fs/fatfs/fatfs_vfs.c
+++ b/fs/fatfs/fatfs_vfs.c
@@ -170,6 +170,8 @@ const struct mountpt_operations g_fatfs_operations =
   NULL,                /* mmap */
   fatfs_truncate,      /* truncate */
   NULL,                /* poll */
+  NULL,                /* readv */
+  NULL,                /* writev */
 
   fatfs_sync,          /* sync */
   fatfs_dup,           /* dup */

--- a/fs/yaffs/yaffs_vfs.c
+++ b/fs/yaffs/yaffs_vfs.c
@@ -167,6 +167,8 @@ const struct mountpt_operations g_yaffs_operations =
   NULL,                    /* mmap */
   yaffs_vfs_truncate,      /* truncate */
   NULL,                    /* poll */
+  NULL,                    /* readv */
+  NULL,                    /* writev */
 
   yaffs_vfs_sync,          /* sync */
   yaffs_vfs_dup,           /* dup */


### PR DESCRIPTION
## Summary
Fix error: initialization of 'ssize_t (*)(struct file *, const struct…
… uio *)'

Fix build break after #87

## Impact
Fix CI break after fs header add ops.

## Testing
CI, local qemu  arm-v7a
