### PR TITLE
Add BATIOC_CAPACITY BATIOC_CHIPID for rpmsgdev

### DIFF
--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -613,6 +613,8 @@ static ssize_t rpmsgdev_ioctl_arglen(int cmd)
       case BATIOC_TEMPERATURE:
       case BATIOC_INPUT_CURRENT:
       case BATIOC_STATE:
+      case BATIOC_CAPACITY:
+      case BATIOC_CHIPID:
         return sizeof(int);
       case TUNSETIFF:
       case TUNGETIFF:


### PR DESCRIPTION
## Summary
add BATIOC_CAPACITY & BATIOC_CHIPID ioctl support.

## Impact
will support more feature in rpmsg dev.

## Testing
CI-test
