### PR TITLE
goldfish_memorymap:Resize VIRT_FLASH_PSECTION

### DIFF
--- a/arch/arm/src/goldfish/goldfish_memorymap.h
+++ b/arch/arm/src/goldfish/goldfish_memorymap.h
@@ -38,7 +38,7 @@
 
 /* Goldfish virt Physical Memory Map ****************************************/
 
-#define VIRT_FLASH_PSECTION      0x00000000  /* 0x00000000-0x08000000 */
+#define VIRT_FLASH_PSECTION      0x00600000  /* 0x00600000-0x08000000 */
 #define VIRT_IO_PSECTION         0x08000000  /* 0x08000000-0x0f000000 */
 #define VIRT_PCIE_PSECTION       0x10000000  /* 0x10000000-0x40000000 */
 #define VIRT_DDR_PSECTION        0x40000000  /* 0x40000000-0x50000000 */
@@ -52,7 +52,7 @@
 
 /* Sizes of memory regions in bytes. */
 
-#define VIRT_FLASH_SECSIZE       (128*1024*1024)
+#define VIRT_FLASH_SECSIZE       (122*1024*1024)
 #define VIRT_IO_SECSIZE          (112*1024*1024)
 #define VIRT_PCIE_SECSIZE        (3*256*1024*1024)
 #define VIRT_DDR_SECSIZE         (256*1024*1024)


### PR DESCRIPTION
## Summary
Adjust VIRT_FLASH_PSECTION from 0x00000000-0x08000000 -> 0x00600000-0x08000000 The above changes avoid the problem of directly restarting when the process accesses/executes at address 0x0 without causing assert

## Impact
Adjusted goldfish's memorymap for tuning

## Testing
Test in QEMU
Now when accessing the 0x0 address (accessing a null pointer), an assert will be triggered
