### PR TITLE
fs_procfs:Fix closedir should handle the release dir handle on a case-by-case basis

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -792,9 +792,24 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 static int procfs_closedir(FAR struct inode *mountpt,
                            FAR struct fs_dirent_s *dir)
 {
+  FAR struct procfs_dir_priv_s *dirpriv;
+  int ret = OK;
+
   DEBUGASSERT(mountpt && dir);
-  fs_heap_free(dir);
-  return OK;
+
+  dirpriv = (FAR struct procfs_dir_priv_s *)dir;
+
+  if (dirpriv->procfsentry != NULL &&
+      dirpriv->procfsentry->ops->closedir != NULL)
+    {
+      ret = dirpriv->procfsentry->ops->closedir(dir);
+    }
+  else
+    {
+      fs_heap_free(dir);
+    }
+
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
fs_procfs is a common location, and there are specific implementations of different modules below it (NET, FS, etc.). Therefore, we should allocate and release it in the same implementation to avoid the problem of inconsistent allocation and release locations.
Therefore, we need to check whether there is a corresponding release function to use in this method, otherwise we execute fs_heap_free by default

## Impact
Adjusted the logic of closedir in fs_procfs, if the corresponding closedir is provided, the default fs_heap_free is not used

## Testing
Test in sim / qemu / actual device project.
Their final results are consistent.