### PR TITLE
hostfs_open:return errno from host

### DIFF
--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -296,7 +296,7 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
     {
       /* Error opening file */
 
-      ret = -EBADF;
+      ret = hf->fd;
       goto errout_with_buffer;
     }
 


### PR DESCRIPTION
## Summary
  In most cases, Vela's ERRNO is aligned with the Host (Linux), so we can directly return the error code from the Host to locate the problem, avoiding masking the problem through EBADF (-9).

## Impact
  When open fails, the errno value passed by the Host is returned.

## Testing
  Test in sim with fs_file_noent (LTP)
  result is OK.

