### PR TITLE
littlefs: Adjust handling of file attr

### DIFF
--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -119,4 +119,12 @@ config FS_LITTLEFS_ATTR_MAX
 
 		Note: Many of tools to generate LITTLEFS images use 1022
 		for this by default.
+
+config FS_LITTLEFS_ATTR_UPDATE
+	bool "LITTLEFS update attributes"
+	depends on FS_LITTLEFS_ATTR_MAX > 0
+	default y
+	---help---
+		Enable support for attributes when create a file.
+
 endif

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -772,7 +772,7 @@ static int littlefs_fstat(FAR const struct file *filep, FAR struct stat *buf)
                                                  &attr, sizeof(attr)));
   if (ret < 0)
     {
-      if (ret != -ENODATA)
+      if (ret != -ENODATA && ret != -ENOENT)
         {
           goto errout;
         }

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -114,8 +114,6 @@ static int     littlefs_dup(FAR const struct file *oldp,
                             FAR struct file *newp);
 static int     littlefs_fstat(FAR const struct file *filep,
                               FAR struct stat *buf);
-static int     littlefs_fchstat(FAR const struct file *filep,
-                                FAR const struct stat *buf, int flags);
 static int     littlefs_truncate(FAR struct file *filep,
                                  off_t length);
 
@@ -148,9 +146,13 @@ static int     littlefs_rename(FAR struct inode *mountpt,
                                FAR const char *newrelpath);
 static int     littlefs_stat(FAR struct inode *mountpt,
                              FAR const char *relpath, FAR struct stat *buf);
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
+static int     littlefs_fchstat(FAR const struct file *filep,
+                                FAR const struct stat *buf, int flags);
 static int     littlefs_chstat(FAR struct inode *mountpt,
                                FAR const char *relpath,
                                FAR const struct stat *buf, int flags);
+#endif
 
 /****************************************************************************
  * Public Data
@@ -178,7 +180,11 @@ const struct mountpt_operations g_littlefs_operations =
   littlefs_sync,          /* sync */
   littlefs_dup,           /* dup */
   littlefs_fstat,         /* fstat */
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
   littlefs_fchstat,       /* fchstat */
+#else
+  NULL,
+#endif
 
   littlefs_opendir,       /* opendir */
   littlefs_closedir,      /* closedir */
@@ -194,7 +200,11 @@ const struct mountpt_operations g_littlefs_operations =
   littlefs_rmdir,         /* rmdir */
   littlefs_rename,        /* rename */
   littlefs_stat,          /* stat */
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
   littlefs_chstat         /* chstat */
+#else
+  NULL,
+#endif
 };
 
 /****************************************************************************
@@ -347,6 +357,7 @@ static int littlefs_open(FAR struct file *filep, FAR const char *relpath,
       goto errout;
     }
 
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
   if (oflags & LFS_O_CREAT)
     {
       struct littlefs_attr_s attr;
@@ -366,6 +377,7 @@ static int littlefs_open(FAR struct file *filep, FAR const char *relpath,
           goto errout_with_file;
         }
     }
+#endif
 
   /* In append mode, we need to set the file pointer to the end of the
    * file.
@@ -788,6 +800,7 @@ errout:
   return ret;
 }
 
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
 static int littlefs_fchstat(FAR const struct file *filep,
                             FAR const struct stat *buf, int flags)
 {
@@ -865,6 +878,7 @@ errout:
   nxmutex_unlock(&fs->lock);
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Name: littlefs_truncate
@@ -1700,6 +1714,7 @@ errout:
   return ret;
 }
 
+#ifdef CONFIG_FS_LITTLEFS_ATTR_UPDATE
 static int littlefs_chstat(FAR struct inode *mountpt,
                            FAR const char *relpath,
                            FAR const struct stat *buf, int flags)
@@ -1773,3 +1788,4 @@ errout:
   nxmutex_unlock(&fs->lock);
   return ret;
 }
+#endif


### PR DESCRIPTION
## Summary
In the littlefs supported by Vela, the definition of file attributes is introduced.
Therefore, by default, when we create a file, we will save the file attributes for subsequent use.
However, some mklfs tools currently do not package the original attributes of the file, so the created image will lose the file attr, so we have dealt with this problem

- CONFIG_FS_LITTLEFS_ATTR_UPDATE controls whether to use fileattr
- Ignore fstat errors about not finding file attributes

## Impact
Adjusted the way littlefs handles different file attrs

## Testing
Test in sim / qemu / actual device project.
Their final results are consistent.
