### PR TITLE
net: Enable dynamic allocation of tcp/udp/ipfwd buffer by default

### DIFF
--- a/net/ipforward/Kconfig
+++ b/net/ipforward/Kconfig
@@ -43,7 +43,7 @@ config NET_IPFORWARD_NSTRUCT
 
 config NET_IPFORWARD_ALLOC_STRUCT
 	int "Dynamic forwarding structures allocation"
-	default 0
+	default 1
 	---help---
 		When set to 0 all dynamic allocations are disabled
 

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -261,7 +261,7 @@ config NET_TCP_NWRBCHAINS
 
 config NET_TCP_ALLOC_WRBCHAINS
 	int "Dynamic I/O buffer chain heads allocation"
-	default 0
+	default 1
 	---help---
 		When set to 0 all dynamic allocations are disabled
 

--- a/net/udp/Kconfig
+++ b/net/udp/Kconfig
@@ -105,7 +105,7 @@ config NET_UDP_NWRBCHAINS
 
 config NET_UDP_ALLOC_WRBCHAINS
 	int "Dynamic I/O buffer chain heads allocation"
-	default 0
+	default 1
 	---help---
 		When set to 0 all dynamic allocations are disabled.
 


### PR DESCRIPTION
## Summary

Enable dynamic allocation of tcp/udp/ipfwd buffer by default for the network stack.

## Impact

Buffer allocations of tcp/udp/ipfwd.

## Testing

SIM.

