### PR TITLE
net/bufpool: Call init automatically on alloc

### DIFF
--- a/net/bluetooth/bluetooth.h
+++ b/net/bluetooth/bluetooth.h
@@ -144,20 +144,6 @@ struct sockaddr;                /* Forward reference */
 void bluetooth_initialize(void);
 
 /****************************************************************************
- * Name: bluetooth_conn_initialize
- *
- * Description:
- *   Initialize the Bluetooth connection structure allocator.  Called
- *   once and only from bluetooth_initialize().
- *
- * Assumptions:
- *   Called early in the initialization sequence
- *
- ****************************************************************************/
-
-void bluetooth_conn_initialize(void);
-
-/****************************************************************************
  * Name: bluetooth_conn_alloc()
  *
  * Description:

--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -82,23 +82,6 @@ static const bt_addr_t g_any_addr =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: bluetooth_conn_initialize
- *
- * Description:
- *   Initialize the Bluetooth connection structure allocator.  Called
- *   once and only from bluetooth_initialize().
- *
- * Assumptions:
- *   Called early in the initialization sequence
- *
- ****************************************************************************/
-
-void bluetooth_conn_initialize(void)
-{
-  NET_BUFPOOL_INIT(g_bluetooth_connections);
-}
-
-/****************************************************************************
  * Name: bluetooth_conn_alloc()
  *
  * Description:

--- a/net/bluetooth/bluetooth_initialize.c
+++ b/net/bluetooth/bluetooth_initialize.c
@@ -48,10 +48,6 @@
 
 void bluetooth_initialize(void)
 {
-  /* Initialize connection structions */
-
-  bluetooth_conn_initialize();
-
   /* Initialize the container allocator */
 
   bluetooth_container_initialize();

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -83,7 +83,6 @@ static dq_queue_t g_active_can_connections;
 
 void can_initialize(void)
 {
-  NET_BUFPOOL_INIT(g_can_connections);
 }
 
 /****************************************************************************

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -311,19 +311,6 @@ extern "C"
 void devif_initialize(void);
 
 /****************************************************************************
- * Name: devif_callback_init
- *
- * Description:
- *   Configure the pre-allocated callback structures into a free list.
- *
- * Assumptions:
- *   This function must be called with the network locked.
- *
- ****************************************************************************/
-
-void devif_callback_init(void);
-
-/****************************************************************************
  * Name: devif_callback_alloc
  *
  * Description:

--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -238,23 +238,6 @@ static bool devif_event_trigger(uint16_t events, uint16_t triggers)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: devif_callback_init
- *
- * Description:
- *   Configure the pre-allocated callback structures into a free list.
- *
- * Assumptions:
- *   Called early in the initialization sequence so that no special
- *   protection is required.
- *
- ****************************************************************************/
-
-void devif_callback_init(void)
-{
-  NET_BUFPOOL_INIT(g_cbprealloc);
-}
-
-/****************************************************************************
  * Name: devif_callback_alloc
  *
  * Description:

--- a/net/devif/devif_initialize.c
+++ b/net/devif/devif_initialize.c
@@ -88,8 +88,5 @@ struct net_stats_s g_netstats;
 
 void devif_initialize(void)
 {
-  /* Initialize callback support */
-
-  devif_callback_init();
 }
 #endif /* CONFIG_NET */

--- a/net/icmp/icmp.h
+++ b/net/icmp/icmp.h
@@ -163,19 +163,6 @@ EXTERN const struct sock_intf_s g_icmp_sockif;
 void icmp_input(FAR struct net_driver_s *dev);
 
 /****************************************************************************
- * Name: icmp_sock_initialize
- *
- * Description:
- *   Initialize the IPPROTO_ICMP socket connection structures.  Called once
- *   and only from the network initialization layer.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_ICMP_SOCKET
-void icmp_sock_initialize(void);
-#endif
-
-/****************************************************************************
  * Name: icmp_alloc
  *
  * Description:

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -73,20 +73,6 @@ static dq_queue_t g_active_icmp_connections;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: icmp_sock_initialize
- *
- * Description:
- *   Initialize the IPPROTO_ICMP socket connection structures.  Called once
- *   and only from the network initialization layer.
- *
- ****************************************************************************/
-
-void icmp_sock_initialize(void)
-{
-  NET_BUFPOOL_INIT(g_icmp_connections);
-}
-
-/****************************************************************************
  * Name: icmp_alloc
  *
  * Description:

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -564,19 +564,6 @@ void icmpv6_rnotify(FAR struct net_driver_s *dev, int result);
 #endif
 
 /****************************************************************************
- * Name: icmpv6_sock_initialize
- *
- * Description:
- *   Initialize the IPPROTO_ICMP socket connection structures.  Called once
- *   and only from the network initialization layer.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_ICMPv6_SOCKET
-void icmpv6_sock_initialize(void);
-#endif
-
-/****************************************************************************
  * Name: icmpv6_alloc
  *
  * Description:

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -74,20 +74,6 @@ static dq_queue_t g_active_icmpv6_connections;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: icmpv6_sock_initialize
- *
- * Description:
- *   Initialize the IPPROTO_ICMP socket connection structures.  Called once
- *   and only from the network initialization layer.
- *
- ****************************************************************************/
-
-void icmpv6_sock_initialize(void)
-{
-  NET_BUFPOOL_INIT(g_icmpv6_connections);
-}
-
-/****************************************************************************
  * Name: icmpv6_alloc
  *
  * Description:

--- a/net/ieee802154/ieee802154.h
+++ b/net/ieee802154/ieee802154.h
@@ -158,20 +158,6 @@ struct sockaddr;              /* Forward reference */
 void ieee802154_initialize(void);
 
 /****************************************************************************
- * Name: ieee802154_conn_initialize
- *
- * Description:
- *   Initialize the IEEE 802.15.4 connection structure allocator.  Called
- *   once and only from ieee802154_initialize().
- *
- * Assumptions:
- *   Called early in the initialization sequence
- *
- ****************************************************************************/
-
-void ieee802154_conn_initialize(void);
-
-/****************************************************************************
  * Name: ieee802154_conn_alloc()
  *
  * Description:

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -77,23 +77,6 @@ static dq_queue_t g_active_ieee802154_connections;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: ieee802154_conn_initialize
- *
- * Description:
- *   Initialize the IEEE 802.15.4 connection structure allocator.  Called
- *   once and only from ieee802154_initialize().
- *
- * Assumptions:
- *   Called early in the initialization sequence
- *
- ****************************************************************************/
-
-void ieee802154_conn_initialize(void)
-{
-  NET_BUFPOOL_INIT(g_ieee802154_connections);
-}
-
-/****************************************************************************
  * Name: ieee802154_conn_alloc()
  *
  * Description:

--- a/net/ieee802154/ieee802154_initialize.c
+++ b/net/ieee802154/ieee802154_initialize.c
@@ -48,10 +48,6 @@
 
 void ieee802154_initialize(void)
 {
-  /* Initialize connection structions */
-
-  ieee802154_conn_initialize();
-
   /* Initialize the container allocator */
 
   ieee802154_container_initialize();

--- a/net/ipforward/ipfwd_alloc.c
+++ b/net/ipforward/ipfwd_alloc.c
@@ -96,8 +96,6 @@ void ipfwd_initialize(void)
    */
 
   DEBUGASSERT(MAX_HDRLEN <= CONFIG_IOB_BUFSIZE);
-
-  NET_BUFPOOL_INIT(g_fwdpool);
 }
 
 /****************************************************************************

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -131,38 +131,16 @@ void net_initialize(void)
   ipfwd_initialize();
 #endif
 
-#ifdef CONFIG_NET_ICMP_SOCKET
-  /* Initialize IPPPROTO_ICMP socket support */
-
-  icmp_sock_initialize();
-#endif
-
-#ifdef CONFIG_NET_ICMPv6_SOCKET
-  /* Initialize IPPPROTO_ICMP6 socket support */
-
-  icmpv6_sock_initialize();
-#endif
-
 #ifdef NET_TCP_HAVE_STACK
   /* Initialize the TCP/IP connection structures */
 
   tcp_initialize();
-
-  /* Initialize the TCP/IP write buffering */
-
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-  tcp_wrbuffer_initialize();
-#endif
 #endif /* CONFIG_NET_TCP */
 
 #ifdef NET_UDP_HAVE_STACK
   /* Initialize the UDP connection structures */
 
   udp_initialize();
-
-#ifdef CONFIG_NET_UDP_WRITE_BUFFERS
-  udp_wrbuffer_initialize();
-#endif
 #endif
 
 #ifdef CONFIG_NET_USRSOCK

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -150,7 +150,6 @@ netlink_get_terminator(FAR const struct nlmsghdr *req)
 
 void netlink_initialize(void)
 {
-  NET_BUFPOOL_INIT(g_netlink_connections);
 }
 
 /****************************************************************************

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -87,7 +87,6 @@ static dq_queue_t g_active_pkt_connections;
 
 void pkt_initialize(void)
 {
-  NET_BUFPOOL_INIT(g_pkt_connections);
 }
 
 /****************************************************************************

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1768,21 +1768,6 @@ bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn);
 
 int psock_tcp_cansend(FAR struct tcp_conn_s *conn);
 
-/****************************************************************************
- * Name: tcp_wrbuffer_initialize
- *
- * Description:
- *   Initialize the list of free write buffers
- *
- * Assumptions:
- *   Called once early initialization.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-void tcp_wrbuffer_initialize(void);
-#endif /* CONFIG_NET_TCP_WRITE_BUFFERS */
-
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
 
 struct tcp_wrbuffer_s;

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -606,7 +606,6 @@ int tcp_selectport(uint8_t domain,
 
 void tcp_initialize(void)
 {
-  NET_BUFPOOL_INIT(g_tcp_connections);
 }
 
 /****************************************************************************

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -63,22 +63,6 @@ NET_BUFPOOL_DECLARE(g_wrbuffer, sizeof(struct tcp_wrbuffer_s),
  ****************************************************************************/
 
 /****************************************************************************
- * Name: tcp_wrbuffer_initialize
- *
- * Description:
- *   Initialize the list of free write buffers
- *
- * Assumptions:
- *   Called once early initialization.
- *
- ****************************************************************************/
-
-void tcp_wrbuffer_initialize(void)
-{
-  NET_BUFPOOL_INIT(g_wrbuffer);
-}
-
-/****************************************************************************
  * Name: tcp_wrbuffer_timedalloc
  *
  * Description:

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -481,21 +481,6 @@ int udp_setsockopt(FAR struct socket *psock, int option,
 #endif
 
 /****************************************************************************
- * Name: udp_wrbuffer_initialize
- *
- * Description:
- *   Initialize the list of free write buffers
- *
- * Assumptions:
- *   Called once early initialization.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_UDP_WRITE_BUFFERS
-void udp_wrbuffer_initialize(void);
-#endif /* CONFIG_NET_UDP_WRITE_BUFFERS */
-
-/****************************************************************************
  * Name: udp_wrbuffer_alloc
  *
  * Description:

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -549,7 +549,6 @@ errout:
 
 void udp_initialize(void)
 {
-  NET_BUFPOOL_INIT(g_udp_connections);
 }
 
 /****************************************************************************

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -62,22 +62,6 @@ NET_BUFPOOL_DECLARE(g_wrbuffer, sizeof(struct udp_wrbuffer_s),
  ****************************************************************************/
 
 /****************************************************************************
- * Name: udp_wrbuffer_initialize
- *
- * Description:
- *   Initialize the list of free write buffers
- *
- * Assumptions:
- *   Called once early initialization.
- *
- ****************************************************************************/
-
-void udp_wrbuffer_initialize(void)
-{
-  NET_BUFPOOL_INIT(g_wrbuffer);
-}
-
-/****************************************************************************
  * Name: udp_wrbuffer_alloc
  *
  * Description:

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -300,8 +300,6 @@ void usrsock_setup_datain(FAR struct usrsock_conn_s *conn,
 
 void usrsock_initialize(void)
 {
-  NET_BUFPOOL_INIT(g_usrsock_connections);
-
   /* Register /dev/usrsock character device. */
 
   usrsock_register();

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -94,11 +94,11 @@
       pool##_buffer[0], \
       prealloc, \
       dynalloc, \
-      nodesize, \
-      SEM_INITIALIZER(NET_BUFPOOL_MAX(prealloc, dynalloc, maxalloc)) \
+      -nodesize, \
+      SEM_INITIALIZER(NET_BUFPOOL_MAX(prealloc, dynalloc, maxalloc)), \
+      { NULL, NULL } \
     };
 
-#define NET_BUFPOOL_INIT(p)         net_bufpool_init(&p)
 #define NET_BUFPOOL_TIMEDALLOC(p,t) net_bufpool_timedalloc(&p, t)
 #define NET_BUFPOOL_TRYALLOC(p)     net_bufpool_timedalloc(&p, 0)
 #define NET_BUFPOOL_ALLOC(p)        net_bufpool_timedalloc(&p, UINT_MAX)
@@ -125,9 +125,9 @@ struct net_bufpool_s
   /* Allocation configuration */
 
   FAR char  *pool;     /* The beginning of the pre-allocated buffer pool */
-  const int  prealloc; /* The number of pre-allocated buffers */
-  const int  dynalloc; /* The number per dynamic allocations */
-  const int  nodesize; /* The size of each node in the pool */
+  int        prealloc; /* The number of pre-allocated buffers */
+  int        dynalloc; /* The number per dynamic allocations */
+  int        nodesize; /* The size of each node in the pool */
 
   sem_t      sem;      /* The semaphore for waiting for free buffers */
 
@@ -366,19 +366,6 @@ FAR void *net_ipv6_payload(FAR struct ipv6_hdr_s *ipv6, FAR uint8_t *proto);
 #ifdef CONFIG_MM_IOB
 uint16_t net_iob_concat(FAR struct iob_s **iob1, FAR struct iob_s **iob2);
 #endif
-
-/****************************************************************************
- * Name: net_bufpool_init
- *
- * Description:
- *   Initialize a network buffer pool.
- *
- * Input Parameters:
- *   pool - The pool to be initialized
- *
- ****************************************************************************/
-
-void net_bufpool_init(FAR struct net_bufpool_s *pool);
 
 /****************************************************************************
  * Name: net_bufpool_timedalloc


### PR DESCRIPTION
## Summary

Call init automatically on alloc for net bufpool.

Note: Initialize function of protocols (tcp, udp, pkt, etc.) are kept empty.

## Impact

Init of buffers.

## Testing

Together with cmocka cases.

