### PR TITLE
drivers/binder: Set thread->looper_need_return false after wake up th…

### DIFF
--- a/drivers/binder/binder.c
+++ b/drivers/binder/binder.c
@@ -295,6 +295,7 @@ static int binder_flush(FAR struct file *filp)
     {
       wait_wake_up(&thread->wait, 0);
       wake_count++;
+      thread->looper_need_return = false;
     }
   }
 


### PR DESCRIPTION
…read.

## Summary

When other commands call binder_flush, binder_flush will be called again when processstate is destructed, causing a crash.

## Impact

binder

## Testing

ci test

