### PR TITLE
gprof: Remove duplicate content

### DIFF
--- a/arch/arm/src/cmake/gcc.cmake
+++ b/arch/arm/src/cmake/gcc.cmake
@@ -132,10 +132,6 @@ if(CONFIG_COVERAGE_ALL)
   add_compile_options(-fprofile-generate -ftest-coverage)
 endif()
 
-if(CONFIG_PROFILE_ALL)
-  add_compile_options(-pg)
-endif()
-
 if(CONFIG_MM_UBSAN_ALL)
   add_compile_options(${CONFIG_MM_UBSAN_OPTION})
 endif()

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -144,10 +144,6 @@ ifeq ($(CONFIG_COVERAGE_TOOLCHAIN),y)
   STDLIBS += -lgcov
 endif
 
-ifneq ($(CONFIG_SIM_PROFILE)$(CONFIG_PROFILE_ALL),)
-  HOSTCFLAGS += -pg
-endif
-
 ifeq ($(CONFIG_STACK_COLORATION),y)
   CSRCS += sim_checkstack.c
 endif


### PR DESCRIPTION
## Summary

    1. arch/arm/src/cmake/gcc.cmake: The same judgment has been made in line 164
    2. boards/sim/sim/sim/scripts/Make.defs: arch/sim/src/Makefile also has in line 147
 
## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

