### PR TITLE
sim: Add compiler selection

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -15,28 +15,38 @@ config HOST_X86_64
 	select ARCH_HAVE_STACKCHECK
 	select LIBC_ARCH_ELF_64BIT if LIBC_ARCH_ELF && !SIM_M32
 	select ARCH_HAVE_MATH_H
-	select ARCH_TOOLCHAIN_GNU
 
 config HOST_X86
 	bool "x86"
 	select ARCH_HAVE_STACKCHECK
-	select ARCH_TOOLCHAIN_GNU
 
 config HOST_ARM
 	bool "arm"
 	select ARCH_HAVE_STACKCHECK
-	select ARCH_TOOLCHAIN_GNU
 
 config HOST_ARM64
 	bool "arm64"
 	select ARCH_HAVE_STACKCHECK
-	select ARCH_TOOLCHAIN_GNU
 
 endchoice # Host CPU Type
 
 config ARCH_CHIP
 	string
 	default "sim"
+
+choice
+	prompt "Toolchain Selection"
+	default SIM_TOOLCHAIN_GCC
+
+config SIM_TOOLCHAIN_GCC
+	bool "Generic GNU toolchain"
+	select ARCH_TOOLCHAIN_GCC
+
+config SIM_TOOLCHAIN_CLANG
+	bool "LLVM Clang toolchain"
+	select ARCH_TOOLCHAIN_CLANG
+
+endchoice
 
 config SIM_M32
 	bool "Build 32-bit simulation on 64-bit machine"


### PR DESCRIPTION
Use gcc by default

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

sim: Add compiler selection

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

