### PR TITLE
net/bufpool: Sync with NuttX's version

### DIFF
--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -94,7 +94,7 @@
       pool##_buffer[0], \
       prealloc, \
       dynalloc, \
-      -nodesize, \
+      -(int)(nodesize), \
       SEM_INITIALIZER(NET_BUFPOOL_MAX(prealloc, dynalloc, maxalloc)), \
       { NULL, NULL } \
     };


### PR DESCRIPTION

## Summary
Sync with NuttX's version, which fixes build break on arm64:

```
nuttx/net/utils/utils.h:97:7: error: overflow in conversion from 'long unsigned int' to 'int' changes value from '18446744073709551464' to '-152' [-Werror=overflow]
   97 |       -nodesize, \
      |       ^
icmp/icmp_conn.c:62:1: note: in expansion of macro 'NET_BUFPOOL_DECLARE'
   62 | NET_BUFPOOL_DECLARE(g_icmp_connections, sizeof(struct icmp_conn_s),
      | ^~~~~~~~~~~~~~~~~~~
```

## Impact

net/bufpool

## Testing

CI

