### PR TITLE
drivers: Fix the missing headers.

### DIFF
--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -39,6 +39,7 @@
 #include <debug.h>
 #include <errno.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/signal.h>
 #include <nuttx/mqueue.h>

--- a/drivers/sensors/fxos8700cq.c
+++ b/drivers/sensors/fxos8700cq.c
@@ -30,6 +30,8 @@
 #include <debug.h>
 #include <errno.h>
 
+#include <nuttx/arch.h>
+#include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/i2c/i2c_master.h>
 


### PR DESCRIPTION
## Summary

This commit added the missing headers for some drivers.

## Impact

This commit should fix compilation errors for `freedom-k64f:demo` and `mikroe-stm32f4:fulldemo`.

## Testing

Tested.


