### PR TITLE
Add rpmsg virtio PM support

### DIFF
--- a/drivers/rpmsg/Kconfig
+++ b/drivers/rpmsg/Kconfig
@@ -129,6 +129,24 @@ config RPMSG_VIRTIO_IVSHMEM
 	---help---
 		This is rpmsg virtio driver based on pci ivshmem.
 
+config RPMSG_VIRTIO_PM
+	bool "rpmsg virtio power management"
+	depends on PM
+	default n
+	---help---
+		If TX/RX buffer is supplied and powered by each CPU.
+		And when one CPU in DEEP sleep, then it's buffer will
+		goto RAM-retention mode, can't access from another CPU.
+		So, we provide this method to resolve this.
+
+config RPMSG_VIRTIO_PM_AUTORELAX
+	bool "rpmsg virtio pm autorelax"
+	depends on RPMSG_VIRTIO_PM
+	default y
+	---help---
+		use wd_timer to auto relax pm
+
+
 if RPMSG_VIRTIO_IVSHMEM
 
 config RPMSG_VIRTIO_IVSHMEM_NAME

--- a/drivers/rpmsg/rpmsg_virtio.c
+++ b/drivers/rpmsg/rpmsg_virtio.c
@@ -134,8 +134,18 @@ static int rpmsg_virtio_buffer_nused(FAR struct rpmsg_virtio_device *rvdev,
 {
   FAR struct virtqueue *vq = rx ? rvdev->rvq : rvdev->svq;
   uint16_t nused = vq->vq_ring.avail->idx - vq->vq_ring.used->idx;
+  bool is_host = rpmsg_virtio_get_role(rvdev) == RPMSG_HOST;
 
-  if ((rpmsg_virtio_get_role(rvdev) == RPMSG_HOST) ^ rx)
+  if (is_host)
+    {
+      RPMSG_VIRTIO_INVALIDATE(vq->vq_ring.used->idx);
+    }
+  else
+    {
+      RPMSG_VIRTIO_INVALIDATE(vq->vq_ring.avail->idx);
+    }
+
+  if (is_host ^ rx)
     {
       return nused;
     }


### PR DESCRIPTION
## Summary
Add rpmsg virtio PM to support pm_stay when send msg & pm_relax when all tx buffer returned;
add headrx to check weather current core miss interrupt by comparing the headrx with the rx vring avail.idx for slave side or
rx vring used.idx for master side.

## Impact
Rpmsg virtio PM can be used by all rpmsg virtio services

## Testing
Pass Vela Test

