### PR TITLE
rptun/rpmsg_virtio: remove cmd initialize

### DIFF
--- a/arch/sim/src/sim/sim_rpmsg_virtio.c
+++ b/arch/sim/src/sim/sim_rpmsg_virtio.c
@@ -88,7 +88,6 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
   struct sim_rpmsg_virtio_dev_s *priv =
     container_of(dev, struct sim_rpmsg_virtio_dev_s, dev);
   struct rpmsg_virtio_rsc_s *rsc;
-  struct rpmsg_virtio_cmd_s *cmd;
 
   priv->shmem = host_allocshmem(priv->shmemname, sizeof(*priv->shmem));
   if (!priv->shmem)
@@ -97,7 +96,6 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
     }
 
   rsc = &priv->shmem->rsc;
-  cmd = RPMSG_VIRTIO_RSC2CMD(rsc);
 
   if (priv->master)
     {
@@ -115,7 +113,6 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
       rsc->rpmsg_vring1.num         = 8;
       rsc->config.r2h_buf_size      = 2048;
       rsc->config.h2r_buf_size      = 2048;
-      cmd->cmd_slave                = 0;
 
       priv->shmem->base = (uintptr_t)priv->shmem;
     }
@@ -128,7 +125,6 @@ sim_rpmsg_virtio_get_resource(struct rpmsg_virtio_s *dev)
           usleep(1000);
         }
 
-      cmd->cmd_master       = 0;
       priv->addrenv[0].va   = (uintptr_t)priv->shmem;
       priv->addrenv[0].pa   = priv->shmem->base;
       priv->addrenv[0].size = sizeof(*priv->shmem);

--- a/arch/sim/src/sim/sim_rptun.c
+++ b/arch/sim/src/sim/sim_rptun.c
@@ -102,7 +102,6 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
 {
   struct sim_rptun_dev_s *priv = container_of(dev,
                                  struct sim_rptun_dev_s, rptun);
-  struct rptun_cmd_s *cmd;
 
   priv->shmem = host_allocshmem(priv->shmemname,
                                 sizeof(*priv->shmem));
@@ -110,8 +109,6 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
     {
       return NULL;
     }
-
-  cmd = RPTUN_RSC2CMD(&priv->shmem->rsc);
 
   priv->raddrenv[0].da   = 0;
   priv->raddrenv[0].size = sizeof(*priv->shmem);
@@ -147,7 +144,6 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
       rsc->config.r2h_buf_size      = 0x800;
       rsc->config.h2r_buf_size      = 0x800;
 
-      cmd->cmd_slave                = 0;
       priv->shmem->base             = (uintptr_t)priv->shmem;
 
       /* The master notifies its slave when it starts again */
@@ -176,8 +172,6 @@ sim_rptun_get_resource(struct rptun_dev_s *dev)
         {
           usleep(1000);
         }
-
-      cmd->cmd_master       = 0;
 
       priv->raddrenv[0].pa  = (uintptr_t)priv->shmem->base;
 

--- a/drivers/rpmsg/rpmsg_virtio_ivshmem.c
+++ b/drivers/rpmsg/rpmsg_virtio_ivshmem.c
@@ -165,7 +165,6 @@ rpmsg_virtio_ivshmem_get_resource(FAR struct rpmsg_virtio_s *dev)
           usleep(1000);
         }
 
-      cmd->cmd_master       = 0;
       priv->addrenv[0].va   = (uint64_t)(uintptr_t)priv->shmem;
       priv->addrenv[0].pa   = priv->shmem->basem;
       priv->addrenv[0].size = priv->shmem_size;

--- a/drivers/rptun/rptun_ivshmem.c
+++ b/drivers/rptun/rptun_ivshmem.c
@@ -194,7 +194,6 @@ rptun_ivshmem_get_resource(FAR struct rptun_dev_s *dev)
       rsc->config.h2r_buf_size      = CONFIG_RPTUN_IVSHMEM_BUFFSIZE;
 
       priv->shmem->rsc_size         = sizeof(struct rptun_rsc_s);
-      cmd->cmd_master               = 0;
       cmd->cmd_slave                = RPTUN_CMD(RPTUN_CMD_READY, 0);
 
       /* Wait untils master is ready, salve need use master base to


### PR DESCRIPTION


## Summary
remove redundant code
## Impact
Do not need initialize cmd in sim_rptun/rpmsg_virtio;
do not need initialize cmd->cmd_master in rptun/rpmsg_virtio_ivshmem.

## Testing
Pass Vela Test
