### PR TITLE
libc/unistd: fixed tasking build issue

### DIFF
--- a/libs/libc/unistd/lib_getoptargp.c
+++ b/libs/libc/unistd/lib_getoptargp.c
@@ -26,8 +26,6 @@
 
 #include <nuttx/config.h>
 
-#include <unistd.h>
-
 #include "unistd.h"
 
 /****************************************************************************

--- a/libs/libc/unistd/lib_getopterrp.c
+++ b/libs/libc/unistd/lib_getopterrp.c
@@ -26,8 +26,6 @@
 
 #include <nuttx/config.h>
 
-#include <unistd.h>
-
 #include "unistd.h"
 
 /****************************************************************************

--- a/libs/libc/unistd/lib_getoptindp.c
+++ b/libs/libc/unistd/lib_getoptindp.c
@@ -26,8 +26,6 @@
 
 #include <nuttx/config.h>
 
-#include <unistd.h>
-
 #include "unistd.h"
 
 /****************************************************************************

--- a/libs/libc/unistd/lib_getoptoptp.c
+++ b/libs/libc/unistd/lib_getoptoptp.c
@@ -26,8 +26,6 @@
 
 #include <nuttx/config.h>
 
-#include <unistd.h>
-
 #include "unistd.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

fixed tasking build issue for unistd lib.

CC:  pthread/pthread_mutexattr_getrobust.c artc I800: creating archive libsched.a
CC:  unistd/lib_getopterrp.c ctc W505: ["unistd/lib_getoptargp.c" 48/29] implicit declaration of function "getoptvars"
ctc W577: ["unistd/lib_getoptargp.c" 48/39] calling a function without a prototype
ctc W524: ["unistd/lib_getoptargp.c" 48/27] conversion of integer to pointer at assignment
ctc E212: ["unistd/lib_getoptargp.c" 49/13] access to incomplete type
ctc W523: ["unistd/lib_getoptargp.c" 49/13] pointers to different types at return

## Impact

tricore tasking build

## Testing

tricore board