### PR TITLE
Fix Error: implicit declaration of function 'enter_critical_section'

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_efuse_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_efuse_lowerhalf.c
@@ -25,6 +25,8 @@
 #include <stdlib.h>
 #include <debug.h>
 #include <assert.h>
+
+#include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/efuse/efuse.h>
 


### PR DESCRIPTION
## Summary

Fix Error: implicit declaration of function 'enter_critical_section'

## Impact

no impact 

## Testing

local test passed

