### PR TITLE
net/netdev: Add netdev_iob_replace_l2 for netdev to avoid misuse

### DIFF
--- a/drivers/net/netdev_upperhalf.c
+++ b/drivers/net/netdev_upperhalf.c
@@ -182,15 +182,8 @@ static void netpkt_put(FAR struct net_driver_s *dev, FAR netpkt_t *pkt,
 
   DEBUGASSERT(dev && pkt);
 
-  /* TODO: Using netdev_iob_release instead of netdev_iob_replace now,
-   *       because netdev_iob_replace sets d_len = L3_LEN and d_buf,
-   *       but we don't want these changes.
-   */
-
   atomic_fetch_add(&upper->lower->quota[type], 1);
-  netdev_iob_release(dev);
-  dev->d_iob = pkt;
-  dev->d_len = netpkt_getdatalen(upper->lower, pkt);
+  netdev_iob_replace_l2(dev, pkt);
 }
 
 /****************************************************************************
@@ -344,7 +337,7 @@ static int netdev_upper_tx(FAR struct net_driver_s *dev)
     {
       /* Put the packet back to the device */
 
-      netdev_iob_replace(dev, iob_remove_queue(&upper->txq));
+      netdev_iob_replace_l2(dev, iob_remove_queue(&upper->txq));
       return netdev_upper_txpoll(dev);
     }
 #endif

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -2,7 +2,8 @@
  * include/nuttx/net/netdev.h
  *
  * SPDX-License-Identifier: BSD-3-Clause
- * SPDX-FileCopyrightText: 2007, 2009, 2011-2018 Gregory Nutt. All rights reserved.
+ * SPDX-FileCopyrightText: 2007, 2009, 2011-2018 Gregory Nutt.
+ * All rights reserved.
  * SPDX-FileCopyrightText: 2001-2003, Adam Dunkels. All rights reserved.
  * SPDX-FileContributor: Gregory Nutt <gnutt@nuttx.org>
  *
@@ -1148,10 +1149,10 @@ void netdev_iob_prepare_dynamic(FAR struct net_driver_s *dev, uint16_t size);
 #endif
 
 /****************************************************************************
- * Name: netdev_iob_replace
+ * Name: netdev_iob_replace / netdev_iob_replace_l2
  *
  * Description:
- *   Replace buffer resources for a given NIC
+ *   Replace IOB for a given NIC, used by net stack (l3-4) / net driver (l2).
  *
  * Assumptions:
  *   The caller has locked the network and new iob is prepared with
@@ -1160,6 +1161,8 @@ void netdev_iob_prepare_dynamic(FAR struct net_driver_s *dev, uint16_t size);
  ****************************************************************************/
 
 void netdev_iob_replace(FAR struct net_driver_s *dev, FAR struct iob_s *iob);
+void netdev_iob_replace_l2(FAR struct net_driver_s *dev,
+                           FAR struct iob_s *iob);
 
 /****************************************************************************
  * Name: netdev_iob_clear

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -127,7 +127,8 @@ void netdev_iob_prepare_dynamic(FAR struct net_driver_s *dev, uint16_t size)
  * Name: netdev_iob_replace
  *
  * Description:
- *   Replace buffer resources for a given NIC
+ *   Replace buffer resources for a given NIC, used by net stack for L3/L4
+ * and set d_buf to l2 (for legacy drivers using d_buf).
  *
  * Assumptions:
  *   The caller has locked the network and new iob is prepared with
@@ -146,6 +147,32 @@ void netdev_iob_replace(FAR struct net_driver_s *dev, FAR struct iob_s *iob)
   dev->d_iob = iob;
   dev->d_buf = NETLLBUF;
   dev->d_len = iob->io_pktlen;
+}
+
+/****************************************************************************
+ * Name: netdev_iob_replace_l2
+ *
+ * Description:
+ *   Replace buffer resources for a given NIC, used by L2 (net drivers) and
+ * set d_len to l2, keep d_buf as NULL.
+ *
+ * Assumptions:
+ *   The caller has locked the network and new iob is prepared with
+ *   l2 gruard size as offset.
+ *
+ ****************************************************************************/
+
+void netdev_iob_replace_l2(FAR struct net_driver_s *dev,
+                           FAR struct iob_s *iob)
+{
+  /* Release previous buffer */
+
+  netdev_iob_release(dev);
+
+  /* Set new buffer */
+
+  dev->d_iob = iob;
+  dev->d_len = iob->io_pktlen + NET_LL_HDRLEN(dev);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Add `netdev_iob_replace_l2` for netdev to avoid misuse, and fix wrong `d_len` for IOBs from `upper->txq` in TX.

## Impact

Netdev upperhalf.

## Testing

Packets from `netdev_upper_tx` captured by `tcpdump`, which have wrong length before this PR.

