### PR TITLE
libc/assert: fix makefile judgment condition error

### DIFF
--- a/libs/libc/assert/Make.defs
+++ b/libs/libc/assert/Make.defs
@@ -22,7 +22,7 @@
 
 CSRCS += lib_assert.c lib_stackchk.c
 
-ifeq ($(CONFIG_LTO_NONE),n)
+ifneq ($(CONFIG_LTO_NONE),y)
   ifeq ($(CONFIG_ARCH_TOOLCHAIN_GHS),y)
     assert/lib_assert.c_CFLAGS += -Onolink
     assert/lib_stackchk.c_CFLAGS += -Onolink


### PR DESCRIPTION
## Summary
libc/assert: fix makefile judgment condition error

## Impact

## Testing
SIM
