### PR TITLE
libc/misc: do not sanitize backtrace_format

### DIFF
--- a/libs/libc/misc/lib_backtrace.c
+++ b/libs/libc/misc/lib_backtrace.c
@@ -459,6 +459,7 @@ void backtrace_symbols_fd(FAR void *const *buffer, int size, int fd)
  *
  ****************************************************************************/
 
+nosanitize_address
 int backtrace_format(FAR char *buffer, int size,
                      FAR void *backtrace[], int depth)
 {


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

We could call backtrace from mm module and access to kasan protected mm_node.backtrace field. Disable kasan check for backtrace_format.

## Impact


## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

