### PR TITLE
drivers/usbdev/cdcecm.c: fix cdcecm netdev can not enter running state

### DIFF
--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1047,6 +1047,7 @@ error:
 static int cdcecm_setinterface(FAR struct cdcecm_driver_s *self,
                                uint16_t interface, uint16_t altsetting)
 {
+  netdev_carrier_on(&self->dev);
   uinfo("interface: %hu, altsetting: %hu\n", interface, altsetting);
   return OK;
 }


### PR DESCRIPTION
## Summary
If the network adapter is not in the running state, packets cannot be sent

## Impact
N/A

## Testing
sim:usbdev

