### PR TITLE
select: fix too small timeout will be counted as 0

### DIFF
--- a/fs/vfs/fs_select.c
+++ b/fs/vfs/fs_select.c
@@ -204,7 +204,7 @@ int select(int nfds, FAR fd_set *readfds, FAR fd_set *writefds,
     {
       /* Calculate the timeout in milliseconds */
 
-      msec = timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
+      msec = timeout->tv_sec * 1000 + (timeout->tv_usec + 999) / 1000;
     }
   else
     {


### PR DESCRIPTION
## Summary
when the timeout period is less than 1000 microseconds, a busyloop problem may occur.

## Impact
N/A

## Testing
sim:local and cortex-m33

