### PR TITLE
air: add api to config irq type

### DIFF
--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -670,7 +670,7 @@ void up_trigger_irq(int irq, cpu_set_t cpuset)
 }
 
 /****************************************************************************
- * Name: arm_gic_irq_trigger
+ * Name: up_set_irq_type
  *
  * Description:
  *   Set the trigger type for the specified IRQ source and the current CPU.
@@ -679,31 +679,36 @@ void up_trigger_irq(int irq, cpu_set_t cpuset)
  *   avoided in common implementations where possible.
  *
  * Input Parameters:
- *   irq - The interrupt request to modify.
- *   edge - False: Active HIGH level sensitive, True: Rising edge sensitive
+ *   irq  - The interrupt request to modify.
+ *   mode - Level sensitive or edge sensitive
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value is returned on any failure.
  *
  ****************************************************************************/
 
-int arm_gic_irq_trigger(int irq, bool edge)
+int up_set_irq_type(int irq, int mode)
 {
   uintptr_t regaddr;
   uint32_t regval;
   uint32_t intcfg;
 
-  if (irq > GIC_IRQ_SGI15 && irq < NR_IRQS)
+  if (!GIC_IS_SGI(irq))
     {
+      if (mode == IRQ_HIGH_LEVEL || mode == IRQ_LOW_LEVEL)
+        {
+          intcfg = INT_ICDICFR_1N;
+        }
+      else
+        {
+          intcfg = INT_ICDICFR_EDGE | INT_ICDICFR_1N;
+        }
+
       /* Get the address of the Interrupt Configuration Register for this
        * irq.
        */
 
       regaddr = GIC_ICDICFR(irq);
-
-      /* Get the new Interrupt configuration bit setting */
-
-      intcfg = (edge ? (INT_ICDICFR_EDGE | INT_ICDICFR_1N) : INT_ICDICFR_1N);
 
       /* Write the correct interrupt trigger to the Interrupt Configuration
        * Register.

--- a/arch/arm/src/armv7-a/arm_gicv2m.c
+++ b/arch/arm/src/armv7-a/arm_gicv2m.c
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/bits.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/pci/pci.h>
@@ -115,7 +116,7 @@ int up_alloc_irq_msi(uint8_t busno, uint32_t devfn, int *pirq, int num)
   irq = g_v2m.spi_start + offset;
   for (i = 0; i < num; i++)
     {
-      arm_gic_irq_trigger(i + irq, true);
+      up_set_irq_type(i + irq, IRQ_RISING_EDGE);
       pirq[i] = i + irq;
     }
 

--- a/arch/arm/src/armv7-a/gic.h
+++ b/arch/arm/src/armv7-a/gic.h
@@ -621,6 +621,8 @@
 #define GIC_IRQ_SGI14            14 /* Software Generated Interrupt (SGI) 14 */
 #define GIC_IRQ_SGI15            15 /* Software Generated Interrupt (SGI) 15 */
 
+#define GIC_IRQ_PPI0             16
+
 #define GIC_IRQ_VM               25 /* Virtual Maintenance Interrupt (VM) PPI(6) */
 #define GIC_IRQ_HTM              26 /* Hypervisor Timer (HTM) PPI(5) */
 #define GIC_IRQ_VTM              27 /* Virtual Timer (VTM) PPI(4) */
@@ -628,6 +630,9 @@
 #define GIC_IRQ_STM              29 /* Secure Physical Timer (STM) PPI(1) */
 #define GIC_IRQ_PTM              30 /* Non-secure Physical Timer (PTM) PPI(2) */
 #define GIC_IRQ_IRQ              31 /* Interrupt Request (nIRQ) PPI(3) */
+
+#define GIC_IS_SGI(intid)        ((intid) >= GIC_IRQ_SGI0 && \
+                                  (intid) < GIC_IRQ_PPI0)
 
 /* Shared Peripheral Interrupts (SPI) follow */
 
@@ -743,26 +748,6 @@ void arm_gic0_initialize(void);
  ****************************************************************************/
 
 void arm_gic_initialize(void);
-
-/****************************************************************************
- * Name: arm_gic_irq_trigger
- *
- * Description:
- *   Set the trigger type for the specificd IRQ source and the current CPU.
- *
- *   Since this API is not supported on all architectures, it should be
- *   avoided in common implementations where possible.
- *
- * Input Parameters:
- *   irq - The interrupt request to modify.
- *   edge - False: Active HIGH level sensitive, True: Rising edge sensitive
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value is returned on any failure.
- *
- ****************************************************************************/
-
-int arm_gic_irq_trigger(int irq, bool edge);
 
 /****************************************************************************
  * Name: arm_decodeirq

--- a/arch/arm/src/armv7-r/arm_gicv2.c
+++ b/arch/arm/src/armv7-r/arm_gicv2.c
@@ -608,7 +608,7 @@ void up_trigger_irq(int irq, cpu_set_t cpuset)
 }
 
 /****************************************************************************
- * Name: arm_gic_irq_trigger
+ * Name: up_set_irq_type
  *
  * Description:
  *   Set the trigger type for the specified IRQ source and the current CPU.
@@ -617,31 +617,36 @@ void up_trigger_irq(int irq, cpu_set_t cpuset)
  *   avoided in common implementations where possible.
  *
  * Input Parameters:
- *   irq - The interrupt request to modify.
- *   edge - False: Active HIGH level sensitive, True: Rising edge sensitive
+ *   irq  - The interrupt request to modify.
+ *   mode - Level sensitive or edge sensitive
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value is returned on any failure.
  *
  ****************************************************************************/
 
-int arm_gic_irq_trigger(int irq, bool edge)
+int up_set_irq_type(int irq, int mode)
 {
   uintptr_t regaddr;
   uint32_t regval;
   uint32_t intcfg;
 
-  if (irq > GIC_IRQ_SGI15 && irq < NR_IRQS)
+  if (!GIC_IS_SGI(irq))
     {
+      if (mode == IRQ_HIGH_LEVEL || mode == IRQ_LOW_LEVEL)
+        {
+          intcfg = INT_ICDICFR_1N;
+        }
+      else
+        {
+          intcfg = INT_ICDICFR_EDGE | INT_ICDICFR_1N;
+        }
+
       /* Get the address of the Interrupt Configuration Register for this
        * irq.
        */
 
       regaddr = GIC_ICDICFR(irq);
-
-      /* Get the new Interrupt configuration bit setting */
-
-      intcfg = (edge ? (INT_ICDICFR_EDGE | INT_ICDICFR_1N) : INT_ICDICFR_1N);
 
       /* Write the correct interrupt trigger to the Interrupt Configuration
        * Register.

--- a/arch/arm/src/armv7-r/gic.h
+++ b/arch/arm/src/armv7-r/gic.h
@@ -594,6 +594,8 @@
 #define GIC_IRQ_SGI14            14 /* Software Generated Interrupt (SGI) 14 */
 #define GIC_IRQ_SGI15            15 /* Software Generated Interrupt (SGI) 15 */
 
+#define GIC_IRQ_PPI0             16
+
 #define GIC_IRQ_VM               25 /* Virtual Maintenance Interrupt (VM) PPI(6) */
 #define GIC_IRQ_HTM              26 /* Hypervisor Timer (HTM) PPI(5) */
 #define GIC_IRQ_VTM              27 /* Virtual Timer (VTM) PPI(4) */
@@ -601,6 +603,9 @@
 #define GIC_IRQ_STM              29 /* Secure Physical Timer (STM) PPI(1) */
 #define GIC_IRQ_PTM              30 /* Non-secure Physical Timer (PTM) PPI(2) */
 #define GIC_IRQ_IRQ              31 /* Interrupt Request (nIRQ) PPI(3) */
+
+#define GIC_IS_SGI(intid)        ((intid) >= GIC_IRQ_SGI0 && \
+                                  (intid) < GIC_IRQ_PPI0)
 
 /* Shared Peripheral Interrupts (SPI) follow */
 
@@ -745,26 +750,6 @@ void arm_gic0_initialize(void);
  ****************************************************************************/
 
 void arm_gic_initialize(void);
-
-/****************************************************************************
- * Name: arm_gic_irq_trigger
- *
- * Description:
- *   Set the trigger type for the specificd IRQ source and the current CPU.
- *
- *   Since this API is not supported on all architectures, it should be
- *   avoided in common implementations where possible.
- *
- * Input Parameters:
- *   irq - The interrupt request to modify.
- *   edge - False: Active HIGH level sensitive, True: Rising edge sensitive
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value is returned on any failure.
- *
- ****************************************************************************/
-
-int arm_gic_irq_trigger(int irq, bool edge);
 
 /****************************************************************************
  * Name: arm_decodeirq

--- a/arch/arm/src/armv8-r/arm_gic.h
+++ b/arch/arm/src/armv8-r/arm_gic.h
@@ -328,7 +328,6 @@ bool arm_gic_irq_is_enabled(unsigned int intid);
 int  arm_gic_initialize(void);
 void arm_gic_irq_set_priority(unsigned int intid, unsigned int prio,
                                 uint32_t flags);
-int arm_gic_irq_trigger(unsigned int intid, uint32_t flags);
 
 int arm_gic_raise_sgi(unsigned int sgi_id, uint16_t target_list);
 

--- a/arch/arm/src/armv8-r/arm_gicv3.c
+++ b/arch/arm/src/armv8-r/arm_gicv3.c
@@ -194,7 +194,7 @@ void arm_gic_irq_set_priority(unsigned int intid, unsigned int prio,
 }
 
 /***************************************************************************
- * Name: arm_gic_irq_trigger
+ * Name: up_set_irq_type
  *
  * Description:
  *   Set the trigger type for the specified IRQ source and the current CPU.
@@ -203,30 +203,29 @@ void arm_gic_irq_set_priority(unsigned int intid, unsigned int prio,
  *   avoided in common implementations where possible.
  *
  * Input Parameters:
- *   irq   - The interrupt request to modify.
- *   flags - irq type, IRQ_TYPE_EDGE or IRQ_TYPE_LEVEL
- *           Default is IRQ_TYPE_LEVEL
+ *   irq  - The interrupt request to modify.
+ *   mode - Level sensitive or edge sensitive
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value is returned on any failure.
  *
  ***************************************************************************/
 
-int arm_gic_irq_trigger(unsigned int intid, uint32_t flags)
+int up_set_irq_type(int irq, int mode)
 {
-  uint32_t      idx  = intid / GIC_NUM_INTR_PER_REG;
+  uint32_t      idx  = irq / GIC_NUM_INTR_PER_REG;
   uint32_t      shift;
   uint32_t      val;
-  unsigned long base = GET_DIST_BASE(intid);
+  unsigned long base = GET_DIST_BASE(irq);
 
-  if (!GIC_IS_SGI(intid))
+  if (!GIC_IS_SGI(irq))
     {
-      idx   = intid / GIC_NUM_CFG_PER_REG;
-      shift = (intid & (GIC_NUM_CFG_PER_REG - 1)) * 2;
+      idx   = irq / GIC_NUM_CFG_PER_REG;
+      shift = (irq & (GIC_NUM_CFG_PER_REG - 1)) * 2;
 
       val = getreg32(ICFGR(base, idx));
       val &= ~(GICD_ICFGR_MASK << shift);
-      if (flags & IRQ_TYPE_EDGE)
+      if (mode != IRQ_HIGH_LEVEL && mode != IRQ_LOW_LEVEL)
         {
           val |= (GICD_ICFGR_TYPE << shift);
         }

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -37,6 +37,7 @@
 
 #include <arpa/inet.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/wdog.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
@@ -2579,7 +2580,7 @@ int imx_netinitialize(int intf)
 
   /* Configure as a (high) level interrupt */
 
-  arm_gic_irq_trigger(IMX_IRQ_ENET0, false);
+  up_set_irq_type(IMX_IRQ_ENET0, IRQ_HIG_HLEVEL);
 
 #ifdef CONFIG_NET_ETHERNET
   /* Determine a semi-unique MAC address from MCU UID

--- a/arch/arm/src/imx6/imx_serial.c
+++ b/arch/arm/src/imx6/imx_serial.c
@@ -591,7 +591,7 @@ static int imx_attach(struct uart_dev_s *dev)
     {
       /* Configure as a (high) level interrupt */
 
-      arm_gic_irq_trigger(priv->irq, false);
+      up_set_irq_type(priv->irq, IRQ_HIG_HLEVEL);
 
       /* Enable the interrupt (RX and TX interrupts are still disabled
        * in the UART

--- a/arch/arm/src/imx6/imx_timerisr.c
+++ b/arch/arm/src/imx6/imx_timerisr.c
@@ -244,7 +244,7 @@ void up_timer_initialize(void)
 
   /* Configure as a (rising) edge-triggered interrupt */
 
-  arm_gic_irq_trigger(IMX_IRQ_GPT, true);
+  up_set_irq_type(IMX_IRQ_GPT, IRQ_RISING_EDGE);
 
   /* Attach the timer interrupt vector */
 

--- a/arch/arm64/src/a64/a64_serial.c
+++ b/arch/arm64/src/a64/a64_serial.c
@@ -640,7 +640,8 @@ static int a64_uart_attach(struct uart_dev_s *dev)
 
   /* Set Interrupt Priority in Generic Interrupt Controller v2 */
 
-  arm64_gic_irq_set_priority(port->irq_num, 0, IRQ_TYPE_LEVEL);
+  up_prioritize_irq(port->irq_num, 0);
+  up_set_type_irq(port->irq_num, IRQ_HIGH_LEVEL);
 
   /* Enable UART Interrupt */
 

--- a/arch/arm64/src/a64/a64_twi.c
+++ b/arch/arm64/src/a64/a64_twi.c
@@ -1843,7 +1843,8 @@ static void twi_hw_initialize(struct a64_twi_priv_s *priv)
 
   /* Set Interrupt Priority in Generic Interrupt Controller v2 */
 
-  arm64_gic_irq_set_priority(priv->config->irq, IRQ_TYPE_LEVEL, 0);
+  up_prioritize_irq(priv->config->irq, 0);
+  up_set_type_irq(priv->config->irq, IRQ_HIGH_LEVEL);
 
   /* Enable TWI Interrupt */
 

--- a/arch/arm64/src/common/arm64_gic.h
+++ b/arch/arm64/src/common/arm64_gic.h
@@ -298,7 +298,6 @@ bool arm64_gic_irq_is_enabled(unsigned int intid);
 int  arm64_gic_initialize(void);
 void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
                                 uint32_t flags);
-int arm64_gic_irq_trigger(unsigned int intid, uint32_t flags);
 
 /****************************************************************************
  * Name: arm64_decodeirq
@@ -319,7 +318,6 @@ uint64_t * arm64_decodeirq(uint64_t *regs);
 
 void arm64_gic_raise_sgi(unsigned int sgi_id, uint16_t target_list);
 
-int arm64_gicv_irq_trigger(int irq, bool edge);
 #ifdef CONFIG_ARM64_GICV2M
 int arm64_gic_v2m_initialize(void);
 #endif

--- a/arch/arm64/src/common/arm64_gic.h
+++ b/arch/arm64/src/common/arm64_gic.h
@@ -244,10 +244,6 @@
 #define GICD_ICFGR_MASK             BIT_MASK(2)
 #define GICD_ICFGR_TYPE             BIT(1)
 
-/* BIT(0) reserved for IRQ_ZERO_LATENCY */
-#define IRQ_TYPE_LEVEL              BIT(1)
-#define IRQ_TYPE_EDGE               BIT(2)
-
 #define GIC_SPI_INT_BASE            32
 #define GIC_SPI_MAX_INTID           1019
 #define GIC_IS_SPI(intid)   (((intid) >= GIC_SPI_INT_BASE) && \
@@ -256,10 +252,6 @@
 /* GITCD_IROUTER */
 #define GIC_DIST_IROUTER            0x6000
 #define IROUTER(base, n)    (base + GIC_DIST_IROUTER + (n) * 8)
-
-/* BIT(0) reserved for IRQ_ZERO_LATENCY */
-#define IRQ_TYPE_LEVEL              BIT(1)
-#define IRQ_TYPE_EDGE               BIT(2)
 
 #define IRQ_DEFAULT_PRIORITY        0xa0
 
@@ -296,8 +288,6 @@
 
 bool arm64_gic_irq_is_enabled(unsigned int intid);
 int  arm64_gic_initialize(void);
-void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
-                                uint32_t flags);
 
 /****************************************************************************
  * Name: arm64_decodeirq

--- a/arch/arm64/src/common/arm64_gicv2.c
+++ b/arch/arm64/src/common/arm64_gicv2.c
@@ -1372,56 +1372,6 @@ int up_set_irq_type(int irq, int mode)
 }
 
 /****************************************************************************
- * Name: arm64_gic_irq_set_priority
- *
- * Description:
- *   Set the interrupt priority and type.
- *
- *   If CONFIG_SMP is not selected, the cpuset is ignored and SGI is sent
- *   only to the current CPU.
- *
- * Input Parameters
- *   intid  - The SGI interrupt ID (0-15)
- *   prio   - The interrupt priority
- *   flags  - Bit IRQ_TYPE_EDGE is 1 if interrupt should be edge-triggered
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
-                                uint32_t flags)
-{
-  int ret;
-
-  /* Disable the interrupt */
-
-  up_disable_irq(intid);
-
-  /* Set the interrupt priority */
-
-  ret = up_prioritize_irq(intid, prio);
-  DEBUGASSERT(ret == OK);
-
-  /* Configure interrupt type */
-
-  if (!GIC_IS_SGI(intid))
-    {
-      if (flags & IRQ_TYPE_EDGE)
-        {
-          ret = up_set_irq_type(intid, IRQ_RISING_EDGE);
-          DEBUGASSERT(ret == OK);
-        }
-      else
-        {
-          ret = up_set_irq_type(intid, IRQ_HIGH_LEVEL);
-          DEBUGASSERT(ret == OK);
-        }
-    }
-}
-
-/****************************************************************************
  * Name: arm64_gic_initialize
  *
  * Description:

--- a/arch/arm64/src/common/arm64_gicv2.c
+++ b/arch/arm64/src/common/arm64_gicv2.c
@@ -1316,7 +1316,7 @@ void up_trigger_irq(int irq, cpu_set_t cpuset)
 }
 
 /****************************************************************************
- * Name: arm64_gicv_irq_trigger
+ * Name: up_set_irq_type
  *
  * Description:
  *   Set the trigger type for the specified IRQ source and the current CPU.
@@ -1325,31 +1325,36 @@ void up_trigger_irq(int irq, cpu_set_t cpuset)
  *   avoided in common implementations where possible.
  *
  * Input Parameters:
- *   irq - The interrupt request to modify.
- *   edge - False: Active HIGH level sensitive, True: Rising edge sensitive
+ *   irq  - The interrupt request to modify.
+ *   mode - Level sensitive or edge sensitive
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value is returned on any failure.
  *
  ****************************************************************************/
 
-int arm64_gicv_irq_trigger(int irq, bool edge)
+int up_set_irq_type(int irq, int mode)
 {
   uintptr_t regaddr;
   uint32_t regval;
   uint32_t intcfg;
 
-  if (irq > GIC_IRQ_SGI15 && irq < NR_IRQS)
+  if (!GIC_IS_SGI(irq))
     {
+      if (mode == IRQ_HIGH_LEVEL || mode == IRQ_LOW_LEVEL)
+        {
+          intcfg = INT_ICDICFR_1N;
+        }
+      else
+        {
+          intcfg = INT_ICDICFR_EDGE | INT_ICDICFR_1N;
+        }
+
       /* Get the address of the Interrupt Configuration Register for this
        * irq.
        */
 
       regaddr = GIC_ICDICFR(irq);
-
-      /* Get the new Interrupt configuration bit setting */
-
-      intcfg = (edge ? (INT_ICDICFR_EDGE | INT_ICDICFR_1N) : INT_ICDICFR_1N);
 
       /* Write the correct interrupt trigger to the Interrupt Configuration
        * Register.
@@ -1405,12 +1410,12 @@ void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
     {
       if (flags & IRQ_TYPE_EDGE)
         {
-          ret = arm64_gicv_irq_trigger(intid, true);
+          ret = up_set_irq_type(intid, IRQ_RISING_EDGE);
           DEBUGASSERT(ret == OK);
         }
       else
         {
-          ret = arm64_gicv_irq_trigger(intid, false);
+          ret = up_set_irq_type(intid, IRQ_HIGH_LEVEL);
           DEBUGASSERT(ret == OK);
         }
     }

--- a/arch/arm64/src/common/arm64_gicv2m.c
+++ b/arch/arm64/src/common/arm64_gicv2m.c
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/bits.h>
 #include <nuttx/spinlock.h>
@@ -130,7 +131,7 @@ int up_alloc_irq_msi(uint8_t busno, uint32_t devfn, int *pirq, int num)
   irq = g_v2m.spi_start + offset;
   for (i = 0; i < num; i++)
     {
-      arm64_gicv_irq_trigger(i + irq, true);
+      up_set_irq_type(i + irq, IRQ_RISING_EDGE);
       pirq[i] = irq + i;
     }
 

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -201,7 +201,7 @@ void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
 }
 
 /***************************************************************************
- * Name: arm64_gic_irq_trigger
+ * Name: up_set_irq_type
  *
  * Description:
  *   Set the trigger type for the specified IRQ source and the current CPU.
@@ -210,30 +210,29 @@ void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
  *   avoided in common implementations where possible.
  *
  * Input Parameters:
- *   irq   - The interrupt request to modify.
- *   flags - irq type, IRQ_TYPE_EDGE or IRQ_TYPE_LEVEL
- *           Default is IRQ_TYPE_LEVEL
+ *   irq  - The interrupt request to modify.
+ *   mode - Level sensitive or edge sensitive
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value is returned on any failure.
  *
  ***************************************************************************/
 
-int arm64_gic_irq_trigger(unsigned int intid, uint32_t flags)
+int up_set_irq_type(int irq, int mode)
 {
-  uint32_t      idx  = intid / GIC_NUM_INTR_PER_REG;
+  uint32_t      idx  = irq / GIC_NUM_INTR_PER_REG;
   uint32_t      shift;
   uint32_t      val;
-  unsigned long base = GET_DIST_BASE(intid);
+  unsigned long base = GET_DIST_BASE(irq);
 
-  if (!GIC_IS_SGI(intid))
+  if (!GIC_IS_SGI(irq))
     {
-      idx   = intid / GIC_NUM_CFG_PER_REG;
-      shift = (intid & (GIC_NUM_CFG_PER_REG - 1)) * 2;
+      idx   = irq / GIC_NUM_CFG_PER_REG;
+      shift = (irq & (GIC_NUM_CFG_PER_REG - 1)) * 2;
 
       val = getreg32(ICFGR(base, idx));
       val &= ~(GICD_ICFGR_MASK << shift);
-      if (flags & IRQ_TYPE_EDGE)
+      if (mode != IRQ_HIGH_LEVEL && mode != IRQ_LOW_LEVEL)
         {
           val |= (GICD_ICFGR_TYPE << shift);
         }

--- a/arch/arm64/src/common/arm64_gicv3.c
+++ b/arch/arm64/src/common/arm64_gicv3.c
@@ -164,42 +164,6 @@ static inline void arm64_gic_write_irouter(uint64_t val, unsigned int intid)
   putreg64(val, addr);
 }
 
-void arm64_gic_irq_set_priority(unsigned int intid, unsigned int prio,
-                                uint32_t flags)
-{
-  uint32_t      mask  = BIT(intid & (GIC_NUM_INTR_PER_REG - 1));
-  uint32_t      idx   = intid / GIC_NUM_INTR_PER_REG;
-  uint32_t      shift;
-  uint32_t      val;
-  unsigned long base = GET_DIST_BASE(intid);
-
-  /* Disable the interrupt */
-
-  putreg32(mask, ICENABLER(base, idx));
-  gic_wait_rwp(intid);
-
-  /* PRIORITYR registers provide byte access */
-
-  putreg8(prio & GIC_PRI_MASK, IPRIORITYR(base, intid));
-
-  /* Interrupt type config */
-
-  if (!GIC_IS_SGI(intid))
-    {
-      idx     = intid / GIC_NUM_CFG_PER_REG;
-      shift   = (intid & (GIC_NUM_CFG_PER_REG - 1)) * 2;
-
-      val = getreg32(ICFGR(base, idx));
-      val &= ~(GICD_ICFGR_MASK << shift);
-      if (flags & IRQ_TYPE_EDGE)
-        {
-          val |= (GICD_ICFGR_TYPE << shift);
-        }
-
-      putreg32(val, ICFGR(base, idx));
-    }
-}
-
 /***************************************************************************
  * Name: up_set_irq_type
  *

--- a/arch/arm64/src/common/arm64_smpcall.c
+++ b/arch/arm64/src/common/arm64_smpcall.c
@@ -104,7 +104,7 @@ int up_send_smp_sched(int cpu)
 {
   /* Execute SGI2 */
 
-  arm64_gic_raise_sgi(GIC_SMP_SCHED, (1 << cpu));
+  up_trigger_irq(GIC_SMP_SCHED, (1 << cpu));
 
   return OK;
 }

--- a/arch/arm64/src/rk3399/rk3399_serial.c
+++ b/arch/arm64/src/rk3399/rk3399_serial.c
@@ -639,7 +639,8 @@ static int a64_uart_attach(struct uart_dev_s *dev)
 
   /* Set Interrupt Priority in Generic Interrupt Controller v2 */
 
-  arm64_gic_irq_set_priority(port->irq_num, 0, IRQ_TYPE_LEVEL);
+  up_prioritize_irq(port->irq_num, 0);
+  up_set_type_irq(port->irq_num, IRQ_RISING_EDGE);
 
   /* Enable UART Interrupt */
 

--- a/arch/arm64/src/zynq-mpsoc/zynq_serial.c
+++ b/arch/arm64/src/zynq-mpsoc/zynq_serial.c
@@ -772,7 +772,8 @@ static int zynq_uart_attach(struct uart_dev_s *dev)
 
   /* Set Interrupt Priority in Generic Interrupt Controller v2 */
 
-  arm64_gic_irq_set_priority(port->irq_num, 0, IRQ_TYPE_LEVEL);
+  up_prioritize_irq(port->irq_num, 0);
+  up_set_type_irq(port->irq_num, IRQ_HIGH_LEVEL);
 
   /* Enable UART Interrupt */
 

--- a/boards/arm64/a64/pinephone/src/pinephone_touch.c
+++ b/boards/arm64/a64/pinephone/src/pinephone_touch.c
@@ -115,7 +115,8 @@ static int pinephone_gt9xx_irq_attach(const struct gt9xx_board_s *state,
 
   /* Set Interrupt Priority in Generic Interrupt Controller v2 */
 
-  arm64_gic_irq_set_priority(A64_IRQ_PH_EINT, 0, IRQ_TYPE_EDGE);
+  up_prioritize_irq(A64_IRQ_PH_EINT, 0);
+  up_set_type_irq(A64_IRQ_PH_EINT, IRQ_RISING_EDGE);
 
   /* Enable Interrupts for Port PH */
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -92,6 +92,12 @@
  * Pre-processor definitions
  ****************************************************************************/
 
+#define IRQ_RISING_EDGE          0x00
+#define IRQ_FALLING_EDGE         0x01
+#define IRQ_BOTH_EDGE            0x02
+#define IRQ_HIGH_LEVEL           0x03
+#define IRQ_LOW_LEVEL            0x04
+
 #define DEBUGPOINT_NONE          0x00
 #define DEBUGPOINT_WATCHPOINT_RO 0x01
 #define DEBUGPOINT_WATCHPOINT_WO 0x02
@@ -1798,6 +1804,18 @@ void up_affinity_irq(int irq, cpu_set_t cpuset);
 
 #ifdef CONFIG_ARCH_HAVE_IRQTRIGGER
 void up_trigger_irq(int irq, cpu_set_t cpuset);
+#endif
+
+/****************************************************************************
+ * Name: up_set_irq_type
+ *
+ * Description:
+ *   Config an IRQ trigger type.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_ARCH_NOINTC
+int up_set_irq_type(int irq, int mode);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
1. irq: add api to config irq type
2. arch/arm64: add api to config irq type
3. arch/arm: add api to config irq type
4. arch/arm64: use up_prioritize_irq and up_set_trigger_mode_irq instead arm64_gic_irq_set_priority
5. arch/arm64: gicv2 add up_trigger_irq

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

