### PR TITLE
pci:write legacy num to config sapce when enable legacy irq

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1965,6 +1965,52 @@ int pci_connect_irq(FAR struct pci_device_s *dev, FAR int *irq, int num)
 }
 
 /****************************************************************************
+ * Name: pci_enable_irq
+ *
+ * Description:
+ *   Enable legacy irq if available.
+ *
+ * Input Parameters:
+ *   dev - PCI device
+ *   irq - allocated vectors
+ *
+ ****************************************************************************/
+
+void pci_enable_irq(FAR struct pci_device_s *dev, int irq)
+{
+  uint16_t command;
+  uint8_t line;
+
+  pci_read_config_byte(dev, PCI_INTERRUPT_LINE, &line);
+  pci_read_config_word(dev, PCI_COMMAND, &command);
+  command &= ~PCI_COMMAND_INTX_DISABLE;
+  pci_write_config_word(dev, PCI_COMMAND, command);
+  if (line == 0)
+    {
+      pci_write_config_byte(dev, PCI_INTERRUPT_LINE, irq);
+    }
+}
+
+/****************************************************************************
+ * Name: pci_disable_irq
+ *
+ * Description:
+ *   Disable legacy irq.
+ *
+ * Input Parameters:
+ *   dev - PCI device
+ *
+ ****************************************************************************/
+
+void pci_disable_irq(FAR struct pci_device_s *dev)
+{
+  uint16_t command;
+  pci_read_config_word(dev, PCI_COMMAND, &command);
+  command |= PCI_COMMAND_INTX_DISABLE;
+  pci_write_config_word(dev, PCI_COMMAND, command);
+}
+
+/****************************************************************************
  * Name: pci_register_driver
  *
  * Description:

--- a/drivers/pci/pci_ep_test.c
+++ b/drivers/pci/pci_ep_test.c
@@ -542,9 +542,13 @@ static bool pci_ep_test_free_irq(FAR struct pci_ep_test_s *test)
 {
   up_disable_irq(test->irq);
   irq_detach(test->irq);
-  if (test->irq_type != PCI_EP_TEST_IRQ_TYPE_LEGACY)
+  if (test->irq_type >= PCI_EP_TEST_IRQ_TYPE_MSI)
     {
       pci_release_irq(test->pdev, &test->irq, 1);
+    }
+  else if (test->irq_type == PCI_EP_TEST_IRQ_TYPE_LEGACY)
+    {
+      pci_disable_irq(dev);
     }
 
   return true;
@@ -624,6 +628,10 @@ static int pci_ep_test_alloc_irq(FAR struct pci_ep_test_s *test,
           pcierr("Failed to connect MSI %d\n", ret);
           return ret;
         }
+    }
+  else if (irq_type == PCI_EP_TEST_IRQ_TYPE_LEGACY)
+    {
+      pci_enable_irq(dev, test->irq);
     }
 
   ret = irq_attach(test->irq, pci_ep_test_handler, test);

--- a/drivers/pci/pci_qemu_edu.c
+++ b/drivers/pci/pci_qemu_edu.c
@@ -450,10 +450,12 @@ static int pci_qemu_edu_probe(FAR struct pci_device_s *dev)
 
   irq_attach(irq, pci_qemu_edu_interrupt, &priv);
   up_enable_irq(irq);
+  pci_enable_irq(dev, irq);
 
   pci_qemu_edu_test_intx(&priv);
   pci_qemu_edu_test_dma(&priv);
 
+  pci_disable_irq(dev);
   up_disable_irq(irq);
   irq_detach(irq);
 

--- a/include/nuttx/pci/pci.h
+++ b/include/nuttx/pci/pci.h
@@ -834,6 +834,33 @@ void pci_release_irq(FAR struct pci_device_s *dev, FAR int *irq, int num);
 int pci_connect_irq(FAR struct pci_device_s *dev, FAR int *irq, int num);
 
 /****************************************************************************
+ * Name: pci_enable_irq
+ *
+ * Description:
+ *   Enable legacy irq if available.
+ *
+ * Input Parameters:
+ *   dev - PCI device
+ *   irq - allocated vectors
+ *
+ ****************************************************************************/
+
+void pci_enable_irq(FAR struct pci_device_s *dev, int irq);
+
+/****************************************************************************
+ * Name: pci_disable_irq
+ *
+ * Description:
+ *   Disable legacy irq.
+ *
+ * Input Parameters:
+ *   dev - PCI device
+ *
+ ****************************************************************************/
+
+void pci_disable_irq(FAR struct pci_device_s *dev);
+
+/****************************************************************************
  * Name: pci_register_driver
  *
  * Description:


### PR DESCRIPTION
pci:write legacy num to config sapce when enable legacy irq



## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

