### PR TITLE
Pci bar size

### DIFF
--- a/drivers/devicetree/fdt_pci.c
+++ b/drivers/devicetree/fdt_pci.c
@@ -118,22 +118,26 @@ int fdt_pci_ecam_register(FAR const void *fdt)
 
       if ((type & FDT_PCI_TYPE_MASK) == FDT_PCI_TYPE_IO)
         {
-          io.start = fdt_ld_by_cells(ranges + na, pna);
+          io.start = fdt_ld_by_cells(ranges + 1, na -1);
           io.end = io.start + fdt_ld_by_cells(ranges + na + pna, ns);
+          io.offset = fdt_ld_by_cells(ranges + na, pna) - io.start;
         }
       else if ((type & FDT_PCI_PREFTCH) == FDT_PCI_PREFTCH)
         {
-          prefetch.start = fdt_ld_by_cells(ranges + na, pna);
+          prefetch.start = fdt_ld_by_cells(ranges + 1, na - 1);
           prefetch.end = prefetch.start +
                          fdt_ld_by_cells(ranges + na + pna, ns);
+          prefetch.offset = fdt_ld_by_cells(ranges + na, pna) -
+                            prefetch.start;
         }
       else if (((type & FDT_PCI_TYPE_MEM32) == FDT_PCI_TYPE_MEM32 &&
                 sizeof(uintptr_t) == 4) ||
                ((type & FDT_PCI_TYPE_MEM64) == FDT_PCI_TYPE_MEM64 &&
                 sizeof(uintptr_t) == 8))
         {
-          mem.start = fdt_ld_by_cells(ranges + na, pna);
+          mem.start = fdt_ld_by_cells(ranges + 1, na - 1);
           mem.end = mem.start + fdt_ld_by_cells(ranges + na + pna, ns);
+          mem.offset = fdt_ld_by_cells(ranges + na, pna) - mem.start;
         }
     }
 

--- a/drivers/devicetree/fdt_pci.c
+++ b/drivers/devicetree/fdt_pci.c
@@ -118,26 +118,39 @@ int fdt_pci_ecam_register(FAR const void *fdt)
 
       if ((type & FDT_PCI_TYPE_MASK) == FDT_PCI_TYPE_IO)
         {
-          io.start = fdt_ld_by_cells(ranges + 1, na -1);
+          io.start = fdt_ld_by_cells(ranges + 1, na - 1);
           io.end = io.start + fdt_ld_by_cells(ranges + na + pna, ns);
           io.offset = fdt_ld_by_cells(ranges + na, pna) - io.start;
+          io.flags = PCI_RESOURCE_IO;
         }
-      else if ((type & FDT_PCI_PREFTCH) == FDT_PCI_PREFTCH)
+      else if ((type & FDT_PCI_PREFTCH) == FDT_PCI_PREFTCH ||
+               (type & FDT_PCI_TYPE_MASK) == FDT_PCI_TYPE_MEM64)
         {
           prefetch.start = fdt_ld_by_cells(ranges + 1, na - 1);
           prefetch.end = prefetch.start +
                          fdt_ld_by_cells(ranges + na + pna, ns);
           prefetch.offset = fdt_ld_by_cells(ranges + na, pna) -
                             prefetch.start;
+          if ((type & FDT_PCI_PREFTCH) == FDT_PCI_PREFTCH)
+            {
+              prefetch.flags = PCI_RESOURCE_PREFETCH;
+            }
+
+          if ((type & FDT_PCI_TYPE_MASK) == FDT_PCI_TYPE_MEM64)
+            {
+              prefetch.flags |= PCI_RESOURCE_MEM_64;
+            }
+          else
+            {
+              prefetch.flags |= PCI_RESOURCE_MEM;
+            }
         }
-      else if (((type & FDT_PCI_TYPE_MEM32) == FDT_PCI_TYPE_MEM32 &&
-                sizeof(uintptr_t) == 4) ||
-               ((type & FDT_PCI_TYPE_MEM64) == FDT_PCI_TYPE_MEM64 &&
-                sizeof(uintptr_t) == 8))
+      else
         {
           mem.start = fdt_ld_by_cells(ranges + 1, na - 1);
           mem.end = mem.start + fdt_ld_by_cells(ranges + na + pna, ns);
           mem.offset = fdt_ld_by_cells(ranges + na, pna) - mem.start;
+          mem.flags = PCI_RESOURCE_MEM;
         }
     }
 

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -1706,6 +1706,12 @@ FAR void *pci_map_bar_region(FAR struct pci_device_s *dev, int bar,
                              uintptr_t offset, size_t length)
 {
   uintptr_t start = pci_resource_start(dev, bar) + offset;
+
+  if (pci_resource_len(dev, bar) == 0)
+    {
+      return NULL;
+    }
+
   return pci_map_region(dev, start, length);
 }
 

--- a/drivers/pci/pci_drivers.c
+++ b/drivers/pci/pci_drivers.c
@@ -160,6 +160,12 @@ int pci_register_drivers(void)
     }
 #endif
 
+  ret = pci_dev_register();
+  if (ret < 0)
+    {
+      pcierr("pci_dev_register failed, ret=%d\n", ret);
+    }
+
   UNUSED(ret);
   return ret;
 }

--- a/drivers/pci/pci_ecam.c
+++ b/drivers/pci/pci_ecam.c
@@ -152,7 +152,7 @@ static FAR void *pci_ecam_conf_address(FAR const struct pci_bus_s *bus,
   FAR struct pci_ecam_s *ecam = pci_ecam_from_controller(bus->ctrl);
   FAR void *addr;
 
-  addr = (FAR void *)ecam->cfg.start;
+  addr = (FAR void *)(uintptr_t)ecam->cfg.start;
   addr += bus->number << 20;
   addr += PCI_SLOT(devfn) << 15;
   addr += PCI_FUNC(devfn) << 12;

--- a/include/nuttx/pci/pci.h
+++ b/include/nuttx/pci/pci.h
@@ -236,9 +236,9 @@
 
 struct pci_resource_s
 {
-  uintptr_t start;
-  uintptr_t end;
-  uintptr_t offset;
+  uint64_t start;
+  uint64_t end;
+  uint64_t offset;
   unsigned int flags;
 };
 

--- a/include/nuttx/pci/pci.h
+++ b/include/nuttx/pci/pci.h
@@ -238,6 +238,7 @@ struct pci_resource_s
 {
   uintptr_t start;
   uintptr_t end;
+  uintptr_t offset;
   unsigned int flags;
 };
 


### PR DESCRIPTION
1. pci: pci res have pci addr and cpu addr, ecam use map translation pci addr to cpuaddr
2.  pci: add  /dev/pci,used for pciutils
3. pci:map bar should not be zaro len
4. pci: fix pci dev alloc bridge mem error
5.  pci:x86_64 calculate bar size,kvm_set_user_memory_region: KVM_SET_USER_MEMORY_REGION failed


## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

