### PR TITLE
tcp_poll:Modify the TCP poll processing strategy when the network driver is down 

### DIFF
--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -238,6 +238,14 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
         }
     }
 
+  if (conn->dev &&
+      !(netdev_verify(conn->dev) && IFF_IS_UP(conn->dev->d_flags)))
+    {
+      _SO_CONN_SETERRNO(conn, ENETDOWN);
+      eventset |= POLLERR | POLLHUP;
+      goto notify;
+    }
+
   /* Allocate a TCP/IP callback structure */
 
   cb = tcp_callback_alloc(conn);
@@ -356,6 +364,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
   /* Check if any requested events are already in effect */
 
+notify:
   poll_notify(&fds, 1, eventset);
 
 errout_with_lock:


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

when dev is down, tcp_pollsetup returns the value 'OK' and sets the connection status to 'down' and eventset to POLLERR & POLLUP

## Impact

tcp

## Testing

Manual verification

