### PR TITLE
tcp_conn.c:resolve reconnection issues in scene where connection failed due to connection rejected

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -695,6 +695,19 @@ int tcp_connect(FAR struct tcp_conn_s *conn,
                 FAR const struct sockaddr *addr);
 
 /****************************************************************************
+ * Name: tcp_removeconn
+ *
+ * Description:
+ *   remove the connection from the list of active TCP connections
+ *
+ * Assumptions:
+ *   This function is called from network logic with the network locked.
+ *
+ ****************************************************************************/
+
+void tcp_removeconn(FAR struct tcp_conn_s *conn);
+
+/****************************************************************************
  * Name: psock_tcp_connect
  *
  * Description:

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1475,4 +1475,22 @@ errout_with_lock:
   return ret;
 }
 
+/****************************************************************************
+ * Name: tcp_removeconn
+ *
+ * Description:
+ *   remove the connection from the list of active TCP connections
+ *
+ * Assumptions:
+ *   This function is called from network logic with the network locked.
+ *
+ ****************************************************************************/
+
+void tcp_removeconn(FAR struct tcp_conn_s *conn)
+{
+  net_lock();
+  dq_rem(&conn->sconn.node, &g_active_tcp_connections);
+  net_unlock();
+}
+
 #endif /* CONFIG_NET && CONFIG_NET_TCP */

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -241,6 +241,12 @@ static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
 
       ninfo("Resuming: %d\n", pstate->tc_result);
 
+      if (pstate->tc_result != OK)
+        {
+          tcp_removeconn(conn);
+          conn->tcpstateflags = TCP_ALLOCATED;
+        }
+
       /* Stop further callbacks */
 
       psock_teardown_callbacks(pstate, pstate->tc_result);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

After first connection refused happend,The user use the same connection failed,becasue the tcpstateflags is not TCP_ALLOCATED

## Impact

tcp

## Testing

Manual verification

