### PR TITLE
drivers/net/{e1000|igc}: limit no packet is transmit after carrier off

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -498,6 +498,11 @@ static int e1000_transmit(FAR struct netdev_lowerhalf_s *dev,
       return -EINVAL;
     }
 
+  if (!IFF_IS_RUNNING(dev->netdev.d_flags))
+    {
+      return -ENETDOWN;
+    }
+
   /* Store TX packet reference */
 
   priv->tx_pkt[priv->tx_now] = pkt;

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -456,6 +456,11 @@ static int igc_transmit(FAR struct netdev_lowerhalf_s *dev,
       return -EINVAL;
     }
 
+  if (!IFF_IS_RUNNING(dev->netdev.d_flags))
+    {
+      return -ENETDOWN;
+    }
+
   /* Store TX packet reference */
 
   priv->tx_pkt[priv->tx_now] = pkt;


### PR DESCRIPTION

## Summary
if the drvier tx queue is full up during the network cable unplugging, there will be no txdone interrupt after inserting the network cable, transmit cannot be recovered.

Modified to no longer fill the driver with packet when link down.


## Impact
e1000/igc NIC

## Testing
intel NUC board

