### PR TITLE
drivers/net/e1000.c: add PIDVID of e1000 NIC

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -257,6 +257,10 @@ static const struct e1000_type_s g_e1000_82574l =
 static const struct pci_device_id_s g_e1000_id_table[] =
 {
   {
+    PCI_DEVICE(0x8086, 0x1a1c),
+    .driver_data = (uintptr_t)&g_e1000_i219
+  },
+  {
     PCI_DEVICE(0x8086, 0x1a1e),
     .driver_data = (uintptr_t)&g_e1000_i219
   },


### PR DESCRIPTION

## Summary
Added the models supported by the e1000 NIC.

## Impact
e1000 NIC

## Testing
intel NUC board

