### PR TITLE
Syslog inbuffer

### DIFF
--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -165,7 +165,7 @@ void syslog_add_intbuffer(FAR const char *buffer, size_t buflen)
     }
   else
     {
-      syslog_flush_intbuffer(true);
+      syslog_flush_internal(true, sizeof(g_syslog_intbuffer.buffer));
       space = buflen - sizeof(g_syslog_intbuffer.buffer);
       syslog_write_foreach(buffer, space, true);
       circbuf_write(&g_syslog_intbuffer.circ,

--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -94,17 +94,14 @@ static struct syslog_intbuffer_s g_syslog_intbuffer =
  *
  ****************************************************************************/
 
-void syslog_flush_internal(bool force, size_t buflen)
+static void syslog_flush_internal(bool force, size_t buflen)
 {
-  irqstate_t flags;
   char *buffer;
   size_t size;
 
   /* This logic is performed with the scheduler disabled to protect from
    * concurrent modification by other tasks.
    */
-
-  flags = spin_lock_irqsave_wo_note(&g_syslog_intbuffer.splock);
 
   do
     {
@@ -118,8 +115,6 @@ void syslog_flush_internal(bool force, size_t buflen)
         }
     }
   while (size > 0 && buflen > 0);
-
-  spin_unlock_irqrestore_wo_note(&g_syslog_intbuffer.splock, flags);
 }
 
 /****************************************************************************
@@ -201,7 +196,11 @@ void syslog_add_intbuffer(FAR const char *buffer, size_t buflen)
 
 void syslog_flush_intbuffer(bool force)
 {
+  irqstate_t flags;
+
+  flags = spin_lock_irqsave_wo_note(&g_syslog_intbuffer.splock);
   syslog_flush_internal(force, sizeof(g_syslog_intbuffer.buffer));
+  spin_unlock_irqrestore_wo_note(&g_syslog_intbuffer.splock, flags);
 }
 
 #endif /* CONFIG_SYSLOG_INTBUFFER */


### PR DESCRIPTION
## Summary
  When spinlock.h is enabled in a single-core scenario, spinlock reentry and exceptions may occur when spin_lock_irqsave_wo_note is used in syslog_add_intbuffer

## Impact
  Fixed deadlock problem with syslog_inbuffer

## Testing
  Spinlock is turned on in single-core Qemu for testing. It works normally during crash, avoiding being stuck

