### PR TITLE
drivers/serial: extend open_count to uint16_t type in uart_dev_s

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -651,7 +651,7 @@ static int uart_open(FAR struct file *filep)
 {
   FAR struct inode *inode = filep->f_inode;
   FAR uart_dev_t   *dev   = inode->i_private;
-  uint8_t           tmp;
+  uint16_t          tmp;
   int               ret;
 
   /* If the port is the middle of closing, wait until the close is finished.
@@ -686,7 +686,7 @@ static int uart_open(FAR struct file *filep)
   tmp = dev->open_count + 1;
   if (tmp == 0)
     {
-      /* More than 255 opens; uint8_t overflows to zero */
+      /* More than 65535 opens; uint16_t overflows to zero */
 
       ret = -EMFILE;
       goto errout_with_lock;

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -297,7 +297,7 @@ struct uart_dev_s
 {
   /* State data */
 
-  uint8_t              open_count;   /* Number of times the device has been opened */
+  uint16_t             open_count;   /* Number of times the device has been opened */
   uint8_t              escape;       /* Number of the character to be escaped */
 #ifdef CONFIG_SERIAL_REMOVABLE
   volatile bool        disconnected; /* true: Removable device is not connected */


### PR DESCRIPTION
## Summary

drivers/serial: extend open_count to uint16_t type in uart_dev_s

Fix file duplicaion failure(-24) for /dev/console, when may tasks(more than 85) exist.

Bug scene captured：
ap> cu -l /dev/ttyCP
[01/19 06:48:44] [13] [ap] files_duplist: Dup fd 0
[01/19 06:48:44] [13] [ap] 13  0   3       1    0         /dev/console
[01/19 06:48:44] [13] [ap] files_duplist: Dup fd 1
[01/19 06:48:44] [13] [ap] 13  0   3       1    0         /dev/console
[01/19 06:48:44] [13] [ap] files_duplist: file_dup2 failed ret -24 line 765
[01/19 06:48:44] [13] [ap] files_duplist: file_dup2 failed  line 769
[01/19 06:48:44] [1036] [ap] PID FD  FLAGS   TYPE POS       PATH
[01/19 06:48:44] [1036] [ap] 10360   3       1    0         /dev/console
[01/19 06:48:44] [1036] [ap] PID FD  FLAGS   TYPE POS       PATH
[01/19 06:48:44] [1036] [ap] 10360   3       1    0         /dev/console
[01/19 06:48:44] [1036] [ap] 10361   3       1    0         /dev/ttyCP

## Impact

None

## Testing

Verified through SIM and local device.

