### PR TITLE
usbhost: recognize sim usb cdcacm composite device

### DIFF
--- a/drivers/usbhost/usbhost_cdcacm.c
+++ b/drivers/usbhost/usbhost_cdcacm.c
@@ -376,11 +376,18 @@ static bool usbhost_txempty(FAR struct uart_dev_s *uartdev);
  * device.
  */
 
-static const struct usbhost_id_s g_id[4] =
+static const struct usbhost_id_s g_id[5] =
 {
   {
     USB_CLASS_CDC,          /* base     */
     CDC_SUBCLASS_NONE,      /* subclass */
+    CDC_PROTO_NONE,         /* proto    */
+    0,                      /* vid      */
+    0                       /* pid      */
+  },
+  {
+    USB_CLASS_CDC,          /* base     */
+    CDC_SUBCLASS_ACM,       /* subclass */
     CDC_PROTO_NONE,         /* proto    */
     0,                      /* vid      */
     0                       /* pid      */
@@ -414,7 +421,7 @@ static struct usbhost_registry_s g_cdcacm =
 {
   NULL,                   /* flink    */
   usbhost_create,         /* create   */
-  4,                      /* nids     */
+  5,                      /* nids     */
   &g_id[0]                /* id[]     */
 };
 

--- a/drivers/usbhost/usbhost_composite.c
+++ b/drivers/usbhost/usbhost_composite.c
@@ -590,15 +590,17 @@ int usbhost_composite(FAR struct usbhost_hubport_s *hport,
 
           if (desc->type == USB_DESC_TYPE_INTERFACE)
             {
-#ifdef CONFIG_DEBUG_ASSERTIONS
               FAR struct usb_ifdesc_s *ifdesc =
                 (FAR struct usb_ifdesc_s *)desc;
 
               DEBUGASSERT(ifdesc->ifno < 32);
-#endif
+
               /* Increment the count of interfaces */
 
-              nintfs++;
+              if (ifdesc->alt == 0)
+                {
+                  nintfs++;
+                }
             }
 
           /* Check for IAD descriptors that will be used when it is


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

usb host support more cdcacm composite device descriptor.

## Impact

cdcacm

## Testing

selftest in sim.

