### PR TITLE
syslog: add ramlog write multiple bytes for interrupt handlers

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -82,6 +82,7 @@ static const struct syslog_channel_ops_s g_ramlog_channel_ops =
   ramlog_putc,
   ramlog_putc,
   NULL,
+  ramlog_write,
   ramlog_write
 };
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

add ramlog write multiple bytes when in interrupt handlers

## Impact

syslog ramlog

## Testing

selftest

