### PR TITLE
arch/xtensa: change the software interrupt to syscall instruction

### DIFF
--- a/arch/xtensa/include/syscall.h
+++ b/arch/xtensa/include/syscall.h
@@ -42,43 +42,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Select software interrupt number for context-switch.
- * The SW interrupt level must be greater than XCHAL_SYSCALL_LEVEL
- * and less than XCHAL_EXCM_LEVEL.
- * So that we can generate an interrupt when up_irq_save is called.
- * and not generate interrupt when up_irq_disable is called.
- * Return an error if no suitable software interrupt was found.
- */
-
-#ifndef XTENSA_SWINT
-#  ifdef XCHAL_SOFTWARE2_INTERRUPT
-#    if XCHAL_INT_LEVEL(XCHAL_SOFTWARE2_INTERRUPT) > XCHAL_SYSCALL_LEVEL && \
-        XCHAL_INT_LEVEL(XCHAL_SOFTWARE2_INTERRUPT) <= XCHAL_EXCM_LEVEL
-#      undef  XTENSA_SWINT
-#      define XTENSA_SWINT XCHAL_SOFTWARE2_INTERRUPT
-#    endif
-#  endif
-#  ifdef XCHAL_SOFTWARE1_INTERRUPT
-#    if XCHAL_INT_LEVEL(XCHAL_SOFTWARE1_INTERRUPT) > XCHAL_SYSCALL_LEVEL && \
-        XCHAL_INT_LEVEL(XCHAL_SOFTWARE1_INTERRUPT) <= XCHAL_EXCM_LEVEL
-#      undef  XTENSA_SWINT
-#      define XTENSA_SWINT XCHAL_SOFTWARE1_INTERRUPT
-#    endif
-#  endif
-#  ifdef XCHAL_SOFTWARE0_INTERRUPT
-#    if XCHAL_INT_LEVEL(XCHAL_SOFTWARE0_INTERRUPT) > XCHAL_SYSCALL_LEVEL && \
-        XCHAL_INT_LEVEL(XCHAL_SOFTWARE0_INTERRUPT) <= XCHAL_EXCM_LEVEL
-#      undef  XTENSA_SWINT
-#      define XTENSA_SWINT XCHAL_SOFTWARE0_INTERRUPT
-#    endif
-#  endif
-#endif
-#ifndef XTENSA_SWINT
-#  error "There is no suitable sw interrupt in this Xtensa configuration."
-#endif
-
-#define XCHAL_SWINT_CALL        (1 << XTENSA_SWINT)
-
 #define SYS_syscall 0x00
 
 /* This logic uses three system calls {0,1,2} for context switching and one
@@ -207,12 +170,10 @@ static inline uintptr_t sys_call0(unsigned int nbr)
 
   __asm__ __volatile__
   (
-    "movi a3, %1\n"
-    "wsr a3, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0)
-    : "a3", "memory"
+    : "r"(reg0)
+    : "memory"
   );
 
   return reg0;
@@ -233,12 +194,10 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 
   __asm__ __volatile__
   (
-    "movi a4, %1\n"
-    "wsr a4, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1)
-    : "a4", "memory"
+    : "r"(reg0), "r"(reg1)
+    : "memory"
   );
 
   return reg0;
@@ -261,12 +220,10 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
 
   __asm__ __volatile__
   (
-    "movi a5, %1\n"
-    "wsr a5, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2)
-    : "a5", "memory"
+    : "r"(reg0), "r"(reg1), "r"(reg2)
+    : "memory"
   );
 
   return reg0;
@@ -290,13 +247,11 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
 
   __asm__ __volatile__
   (
-    "movi a6, %1\n"
-    "wsr a6, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
+    : "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3)
-    : "a6", "memory"
+    : "memory"
   );
 
   return reg0;
@@ -322,13 +277,11 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
 
   __asm__ __volatile__
   (
-    "movi a7, %1\n"
-    "wsr a7, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
+    : "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3), "r"(reg4)
-    : "a7", "memory"
+    : "memory"
   );
 
   return reg0;
@@ -355,13 +308,11 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
 
   __asm__ __volatile__
   (
-    "movi a8, %1\n"
-    "wsr a8, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
+    : "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3), "r"(reg4), "r"(reg5)
-    : "a8", "memory"
+    : "memory"
   );
 
   return reg0;
@@ -390,13 +341,11 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
   __asm__ __volatile__
   (
-    "movi a9, %1\n"
-    "wsr a9, intset\n"
-    "rsync\n"
+    "syscall\n"
     : "=r"(reg0)
-    : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
+    : "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)
-    : "a9", "memory"
+    : "memory"
   );
 
   return reg0;

--- a/arch/xtensa/src/common/xtensa_dispatch_syscall.S
+++ b/arch/xtensa/src/common/xtensa_dispatch_syscall.S
@@ -95,9 +95,7 @@ xtensa_dispatch_syscall:
   /* Execute the SYS_signal_handler_return syscall (will not return) */
 
   movi   a2, SYS_syscall_return
-  movi   a4, XCHAL_SWINT_CALL
-  wsr    a4, INTSET
-  rsync
+  syscall
 
   .size xtensa_dispatch_syscall, .-xtensa_dispatch_syscall
 

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -197,6 +197,13 @@ _xtensa_level1_handler:
 
 	call0	_xtensa_context_save
 
+	/* Overwrite the PS saved by the exception entry. */
+
+	movi	a2, ~PS_EXCM_MASK
+	l32i	a3, sp, (4 * REG_PS)
+	and	a3, a3, a2
+	s32i	a3, sp, (4 * REG_PS)
+
 	/* Save current SP before (possibly) overwriting it, it's the register save
 	 * area. This value will be used later by dispatch_c_isr to retrieve the
 	 * register save area.
@@ -217,6 +224,13 @@ _xtensa_level1_handler:
 	 */
 
 	dispatch_c_isr	1 XCHAL_INTLEVEL1_MASK a0
+
+	/* Set PS.EXCM to 1 */
+
+	movi	a3, PS_EXCM_MASK
+	l32i	a4, a2, (4 * REG_PS)
+	or	a4, a3, a4
+	s32i	a4, a2, (4 * REG_PS)
 
 	/* Restore registers in preparation to return from interrupt */
 

--- a/arch/xtensa/src/common/xtensa_signal_handler.S
+++ b/arch/xtensa/src/common/xtensa_signal_handler.S
@@ -77,9 +77,7 @@ up_signal_handler:
   /* Execute the SYS_signal_handler_return syscall (will not return) */
 
   movi   a2, SYS_signal_handler_return
-  movi   a3, XCHAL_SWINT_CALL
-  wsr    a3, INTSET
-  rsync
+  syscall
 
   .size up_signal_handler, .-up_signal_handler
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -193,6 +193,13 @@ _xtensa_user_handler:
 
 	mov		a2, RETVAL							/* a2 = address of new state save area */
 
+	/* Set PS.EXCM to 1 */
+
+	movi	a3, PS_EXCM_MASK
+	l32i	a4, a2, (4 * REG_PS)
+	or	a4, a3, a4
+	s32i	a4, a2, (4 * REG_PS)
+
 	/* Restore registers in preparation to return from interrupt */
 
 	call0	_xtensa_context_restore			/* (Preserves a2) */
@@ -235,6 +242,13 @@ _xtensa_syscall_handler:
 
 	call0	_xtensa_context_save
 
+	/* Overwrite the PS saved by the exception entry. */
+
+	movi	a2, ~PS_EXCM_MASK
+	l32i	a3, sp, (4 * REG_PS)
+	and	a3, a3, a2
+	s32i	a3, sp, (4 * REG_PS)
+
 	/* Save EPC (note that this will overwrite the PC saved by the exception
 	 * entry with the correct value skipping the syscall instruction.)
 	 */
@@ -265,8 +279,8 @@ _xtensa_syscall_handler:
 #else
 	/* Get the interruptee's PC and skip over the 'syscall' instruction. */
 
-	rsr		a1, EPC_1						/* a2 = PC of 'syscall' */
-	addi	a0, a1, 3						/* ++PC */
+	rsr		a2, EPC_1						/* a2 = PC of 'syscall' */
+	addi	a0, a2, 3						/* ++PC */
 
 	wsr		a0, EPC_1						/* Update PC */
 	s32i	a0, sp, (4 * REG_PC)
@@ -303,6 +317,13 @@ _xtensa_syscall_handler:
 	 */
 
 	mov		a2, RETVAL							/* Switch to the new register save area */
+
+	/* Set PS.EXCM to 1 */
+
+	movi	a3, PS_EXCM_MASK
+	l32i	a4, a2, (4 * REG_PS)
+	or	a4, a3, a4
+	s32i	a4, a2, (4 * REG_PS)
 
 	/* Restore registers in preparation to return from interrupt */
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -286,6 +286,13 @@ _xtensa_syscall_handler:
 
 	ps_setup	1 a0
 
+	/* Link the pre-exception frame for debugging. At this point, a12 points to the
+	 * allocated and filled exception stack frame (old value of SP in case of
+	 * an interrupt stack).
+	 */
+
+	exception_backtrace a12 1
+
 	movi	ARG1, XTENSA_IRQ_SYSCALL			/* Argument 1: IRQ number */
 	mov		ARG2, a12							/* Argument 2: Top of stack = register save area */
 	CALL	xtensa_irq_dispatch					/* Call xtensa_int_decode */

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -578,11 +578,7 @@ void up_irqinitialize(void)
 
   /* Attach the software interrupt */
 
-  irq_attach(XTENSA_IRQ_SWINT, (xcpt_t)xtensa_swint, NULL);
-
-  /* Enable the software interrupt. */
-
-  up_enable_irq(XTENSA_IRQ_SWINT);
+  irq_attach(XTENSA_IRQ_SYSCALL, xtensa_swint, NULL);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_irq.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_irq.c
@@ -330,11 +330,7 @@ void up_irqinitialize(void)
 
   /* Attach the software interrupt */
 
-  irq_attach(XTENSA_IRQ_SWINT, (xcpt_t)xtensa_swint, NULL);
-
-  /* Enable the software CPU interrupt. */
-
-  up_enable_irq(XTENSA_IRQ_SWINT);
+  irq_attach(XTENSA_IRQ_SYSCALL, xtensa_swint, NULL);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -528,11 +528,7 @@ void up_irqinitialize(void)
 
   /* Attach the software interrupt */
 
-  irq_attach(XTENSA_IRQ_SWINT, (xcpt_t)xtensa_swint, NULL);
-
-  /* Enable the software CPU interrupt. */
-
-  up_enable_irq(XTENSA_IRQ_SWINT);
+  irq_attach(XTENSA_IRQ_SYSCALL, xtensa_swint, NULL);
 }
 
 /****************************************************************************

--- a/libs/libc/machine/xtensa/arch_setjmp.S
+++ b/libs/libc/machine/xtensa/arch_setjmp.S
@@ -132,9 +132,7 @@ setjmp:
   /* Flush registers.  */
   mov a4, a2      # save a2 (jmp_buf)
   movi  a2, SYS_flush_context
-  movi a3, XCHAL_SWINT_CALL
-  wsr  a3, intset
-  isync
+  syscall
   mov a2, a4      # restore a2
 
   /* Copy the register save area at (sp - 16).  */


### PR DESCRIPTION
## Summary

Currently xtensa arch porting is using software interrupt (through write `intset` register) to trigger context switch.
But this put a strict requirement to the chip configuration: 
there must be a software interrupt, it's priority is less or equal to XCHAL_EXCM_LEVEL;
and it's priority must be greater than XCHAL_SYSCALL_LEVEL (the XCHAL_SYSCALL_LEVEL is not a cadence macro, it just means normal hardware interrupt priority).

Since the xtensa arch is very flexible, the chip designer might have not noticed above requirement in chip design phase.
And if the chip has been taped out without this requirement, there is no posibility to port nuttx to the chip.

This PR will try to change the software interrupt to `syscall` instruction.
The `syscall` instruction is a synchronous exception, and is not locked by `PS.intlevel`, which means it's priority is high enough.

## Impact

This PR will impact context switch, interrupt handling, and protect build.

## Testing

`ostest` with below configs  passed.

esp32s3-devkit:nsh 
esp32s3-devkit:tickless 
esp32s3-devkit:knsh 
esp32s3-devkit:smp 
