### PR TITLE
[bug fix] drivers/binder: Rename BIOC_FLUSH to BINDER_FLUSH to avoid …

### DIFF
--- a/drivers/binder/binder.c
+++ b/drivers/binder/binder.c
@@ -295,7 +295,6 @@ static int binder_flush(FAR struct file *filp)
     {
       wait_wake_up(&thread->wait, 0);
       wake_count++;
-      thread->looper_need_return = false;
     }
   }
 
@@ -421,7 +420,7 @@ static int binder_ioctl(FAR struct file *filp, int cmd, unsigned long arg)
       break;
     }
 
-    case BIOC_FLUSH:
+    case BINDER_FLUSH:
     {
       ret = binder_flush(filp);
       break;

--- a/include/nuttx/android/binder.h
+++ b/include/nuttx/android/binder.h
@@ -54,6 +54,7 @@
 #define BINDER_GET_FROZEN_INFO              BINDER_IOWR('b', 15, struct binder_frozen_status_info)
 #define BINDER_ENABLE_ONEWAY_SPAM_DETECTION BINDER_IOW('b', 16, uint32_t)
 #define BINDER_GET_EXTENDED_ERROR           BINDER_IOWR('b', 17, struct binder_extended_error)
+#define BINDER_FLUSH                        BINDER_IO('b', 18)
 
 #define B_PACK_CHARS(c1, c2, c3, c4) \
   (((c1) << 24) | ((c2) << 16) | ((c3) << 8) | (c4))


### PR DESCRIPTION
…conflict with system flush.

1. revert 4946904, This patch is to solve the crash problem caused by reboot operation. The phenomenon is: when reboot operation is executed, the system will call binder_flush, which will cause the use after free to be called when proc is destroyed.

2. Now, we can rename BIOC_FLUSH to BINDER_FLUSH to avoid system call binder_flush.

3. why revert 4946904, because when we set looper_need_return in advance, it will cause the child thread of the binder thread pool to be unable to exit when it really wants to exit.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

## Impact

## Testing

