### PR TITLE
modlib:r_offset is a unsigned symbol,cannot be less than 0

### DIFF
--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -586,8 +586,7 @@ static int modlib_relocateadd(FAR struct module_s *modp,
 
       /* Calculate the relocation address. */
 
-      if (rela->r_offset < 0 ||
-          rela->r_offset > dstsec->sh_size)
+      if (rela->r_offset > dstsec->sh_size)
         {
           berr("ERROR: Section %d reloc %d: "
                "Relocation address out of range, "


### PR DESCRIPTION
## Summary

modlib:r_offset is a unsigned symbol,cannot be less than 0

## Impact

code fix

## Testing

vela

