### PR TITLE
arm:modlib not support unwind table now

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -536,10 +536,15 @@ LDMODULEFLAGS = -r -T $(call CONVERT_PATH,$(TOPDIR)/libs/libc/modlib/gnu-elf.ld)
 CELFFLAGS = $(CFLAGS) -fvisibility=hidden -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS)-fvisibility=hidden
 
+ifeq ($(CONFIG_UNWINDER_ARM),y)
+  CELFFLAGS += -fno-unwind-tables -fno-asynchronous-unwind-tables
+  CXXELFFLAGS += -fno-unwind-tables -fno-asynchronous-unwind-tables
+endif
+
 ifeq ($(CONFIG_PIC),y)
   CFLAGS += --fixed-r10
-  CELFFLAGS += $(PICFLAGS) -mpic-register=r10
-  CXXELFFLAGS += $(PICFLAGS) -mpic-register=r10
+  CELFFLAGS += $(PICFLAGS) -mpic-register=r10 -fno-unwind-tables -fno-asynchronous-unwind-tables
+  CXXELFFLAGS += $(PICFLAGS) -mpic-register=r10 -fno-unwind-tables -fno-asynchronous-unwind-tables
 
   # Generate an executable elf, need to ignore undefined symbols
   LDELFFLAGS += --unresolved-symbols=ignore-in-object-files --emit-relocs


### PR DESCRIPTION
## Summary

arm:modlib not support unwind table now, so remove the unwind table flag in module build
```
modlib_read: Read 64 bytes from offset 192665
modlib_symvalue: ERROR: SHN_UNDEF: Exported symbol "__gnu_Unwind_Find_exidx" not found
modlib_relocate: ERROR: Section 2 reloc 12: Failed to get value of symbol[246]: -2
elf_loadbinary: Failed to bind symbols program binary: -2
builtin_loadbinary: Loading file: /mnt/sotest
```

## Impact

module load

## Testing

vela
