### PR TITLE
spinlock: UP_DSB, UP_DMB redefined

### DIFF
--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -61,9 +61,6 @@
  *            all memory accesses are complete
  */
 
-#define UP_DSB() __asm__ __volatile__ ("dsb sy" : : : "memory")
-#define UP_DMB() __asm__ __volatile__ ("dmb st" : : : "memory")
-
 #ifdef CONFIG_ARM_HAVE_WFE_SEV
 #define UP_WFE() __asm__ __volatile__ ("wfe" : : : "memory")
 #define UP_SEV() __asm__ __volatile__ ("sev" : : : "memory")


### PR DESCRIPTION
1. spinlock.h: UP_DSB, UP_DMB redefined


## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

