### PR TITLE
cpufreq procfs: fix warning in snprintf fmt

### DIFF
--- a/drivers/cpufreq/cpufreq_procfs.c
+++ b/drivers/cpufreq/cpufreq_procfs.c
@@ -198,7 +198,7 @@ static ssize_t cpufreq_read(FAR struct file *filep,
     {
       linesize += snprintf(line + linesize,
                            CPUFREQ_LINELEN - linesize,
-                           "%p: %d, %d\n",
+                           "%p: %"PRId32" %"PRId32"\n",
                            qos->caller,
                            freq_qos_read_value(qos->min.qos, FREQ_QOS_MIN),
                            freq_qos_read_value(qos->max.qos, FREQ_QOS_MAX));


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary
replace "%d" to %"PRId32"
## Impact
fix warning in snprintf fmt
## Testing
ostest

