### PR TITLE
driver/note: fix overflowed integer argument

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -104,6 +104,10 @@
 #define note_vprintf(drv, ip, fmt, va)                                       \
   ((drv)->ops->vprintf && ((drv)->ops->vprintf(drv, ip, fmt, va), true))
 
+#define BUFFER_SIZE 256
+static_assert(BUFFER_SIZE >= sizeof(struct note_event_s),
+              "Buffer size too small");
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -1474,7 +1478,7 @@ void sched_note_event_ip(uint32_t tag, uintptr_t ip, uint8_t event,
   FAR struct note_event_s *note;
   FAR struct note_driver_s **driver;
   bool formatted = false;
-  char data[256];
+  char data[BUFFER_SIZE];
   unsigned int length;
   FAR struct tcb_s *tcb = this_task();
 
@@ -1527,7 +1531,7 @@ void sched_note_vprintf_ip(uint32_t tag, uintptr_t ip, FAR const char *fmt,
   FAR struct note_printf_s *note;
   FAR struct note_driver_s **driver;
   bool formatted = false;
-  uint8_t data[256];
+  uint8_t data[BUFFER_SIZE];
   size_t length = 0;
   FAR struct tcb_s *tcb = this_task();
 


### PR DESCRIPTION
## Summary
static_assert is used to ensure that the buffer size is at least large enough to accommodate the struct note_event_s structure, preventing issues caused by an undersized buffer.

## Impact
if buffer size not large enough for struct, there will be assert.

## Testing
ostest

