### PR TITLE
drivers/thermal: Add support for passive trip point

### DIFF
--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -835,7 +835,7 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
   if (ret < 0)
     {
       therr("Failed to get temperature from zone %s \n", zdev->name);
-      goto unlock;
+      goto delayed_work;
     }
 
   zdev->last_temperature = zdev->temperature;
@@ -895,6 +895,8 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
                  trip_low, trip_high, zdev->name);
         }
     }
+
+delayed_work:
 
   /* Update worker invoke delay */
 

--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -912,6 +912,7 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
           (pos->target != 0 && pos->target != THERMAL_NO_TARGET))
         {
           delay = zdev->params->polling_delay;
+          break;
         }
     }
 

--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -815,6 +815,9 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
 {
   int trip_high = INT_MAX;
   int trip_low  = INT_MIN;
+  FAR struct thermal_instance_s *pos;
+  unsigned int current;
+  clock_t delay;
   int trip;
   int temp;
   int ret;
@@ -893,8 +896,27 @@ void thermal_zone_device_update(FAR struct thermal_zone_device_s *zdev)
         }
     }
 
+  /* Update worker invoke delay */
+
+  delay = zdev->params->passive_delay;
+  list_for_every_entry(&zdev->instance_list, pos,
+                       struct thermal_instance_s, zdev_node)
+    {
+      if (zdev->params->trips[pos->trip].type == THERMAL_PASSIVE)
+        {
+          continue;
+        }
+
+      pos->cdev->ops->get_state(pos->cdev, &current);
+      if ((current != 0 && current != THERMAL_NO_TARGET) ||
+          (pos->target != 0 && pos->target != THERMAL_NO_TARGET))
+        {
+          delay = zdev->params->polling_delay;
+        }
+    }
+
   work_queue(LPWORK, &zdev->monitor, (worker_t)thermal_zone_device_update,
-             zdev, zdev->params->polling_delay);
+             zdev, delay);
 
 unlock:
   nxmutex_unlock(&g_thermal_lock);

--- a/drivers/thermal/thermal_dummy.c
+++ b/drivers/thermal/thermal_dummy.c
@@ -112,7 +112,7 @@ static const struct thermal_zone_trip_s g_dummy_trips[] =
 {
   {.name = "cpu_crit",   .temp = 90, .hyst = 5, .type = THERMAL_CRITICAL},
   {.name = "cpu_alert1", .temp = 70, .hyst = 5, .type = THERMAL_HOT},
-  {.name = "cpu_alert0", .temp = 60, .hyst = 5, .type = THERMAL_NORMAL},
+  {.name = "cpu_alert0", .temp = 60, .hyst = 5, .type = THERMAL_PASSIVE},
 };
 
 static const struct thermal_zone_map_s g_dummy_maps[] =
@@ -143,6 +143,7 @@ static const struct thermal_zone_map_s g_dummy_maps[] =
 static const struct thermal_zone_params_s g_dummy_params =
 {
   .gov_name = "step_wise",
+  .passive_delay = CONFIG_THERMAL_DUMMY_POLLING_DELAY * 2,
   .polling_delay = CONFIG_THERMAL_DUMMY_POLLING_DELAY,
   .trips = g_dummy_trips,
   .num_trips = nitems(g_dummy_trips),
@@ -165,19 +166,19 @@ static struct dummy_zone_device_s g_dummy_zone =
   .temp_jump = true,
 };
 
+static const struct thermal_cooling_device_ops_s g_dummy_cooling_ops =
+{
+  .set_state     = dummy_cdev_set_state,
+  .get_state     = dummy_cdev_get_state,
+  .get_max_state = dummy_cdev_get_max_state,
+};
+
 /* Cooling Device - fan0 */
 
 static struct dummy_cooling_device_s g_dummy_fan0_data =
 {
   .cur_state = 0,
   .max_state = 16,
-};
-
-static const struct thermal_cooling_device_ops_s g_dummy_fan0_ops =
-{
-  .set_state     = dummy_cdev_set_state,
-  .get_state     = dummy_cdev_get_state,
-  .get_max_state = dummy_cdev_get_max_state,
 };
 
 /* Cooling Device - cpufreq */
@@ -338,7 +339,7 @@ int thermal_dummy_init(void)
   /* Cooling Device */
 
   cdev = thermal_cooling_device_register("fan0", &g_dummy_fan0_data,
-                                         &g_dummy_fan0_ops);
+                                         &g_dummy_cooling_ops);
   if (cdev == NULL)
     {
       therr("Register cooling device fan0 failed!\n");

--- a/drivers/thermal/thermal_dummy.c
+++ b/drivers/thermal/thermal_dummy.c
@@ -138,6 +138,13 @@ static const struct thermal_zone_map_s g_dummy_maps[] =
     .high   = 2,
     .weight = 20
   },
+  {
+    .trip_name = "cpu_alert0",
+    .cdev_name = "passive_dev",
+    .low    = THERMAL_NO_LIMIT,
+    .high   = THERMAL_NO_LIMIT,
+    .weight = 20
+  },
 };
 
 static const struct thermal_zone_params_s g_dummy_params =
@@ -205,6 +212,12 @@ static struct dummy_cpufreq_driver_s g_dummy_cpufreq_driver =
     },
   .table = g_dummy_cpufreq_table,
   .table_len = nitems(g_dummy_cpufreq_table),
+};
+#else
+static struct dummy_cooling_device_s g_dummy_passive =
+{
+  .cur_state = 0,
+  .max_state = 1,
 };
 #endif /* CONFIG_THERMAL_DUMMY_CPUFREQ */
 
@@ -333,6 +346,14 @@ int thermal_dummy_init(void)
     {
       therr("Dummy cpufreq driver init failed!\n");
       return ret;
+    }
+#else
+  cdev = thermal_cooling_device_register("passive_dev", &g_dummy_passive,
+                                         &g_dummy_cooling_ops);
+  if (cdev == NULL)
+    {
+      therr("Register cooling device passive_dev failed!\n");
+      return -ENOTSUP;
     }
 #endif /* CONFIG_THERMAL_DUMMY_CPUFREQ */
 

--- a/drivers/thermal/thermal_step_wise.c
+++ b/drivers/thermal/thermal_step_wise.c
@@ -134,6 +134,10 @@ static unsigned int get_target_state(FAR struct thermal_instance_s *instance,
                 return validate_state(instance, throttle, cur_state, 1);
               }
           }
+        else
+          {
+            return validate_state(instance, throttle, cur_state, -1);
+          }
         break;
 
       default:

--- a/include/nuttx/thermal.h
+++ b/include/nuttx/thermal.h
@@ -71,7 +71,8 @@ enum thermal_trend_e
 
 enum thermal_trip_type_e
 {
-  THERMAL_NORMAL,
+  THERMAL_ACTIVE,
+  THERMAL_PASSIVE,
   THERMAL_HOT,
   THERMAL_CRITICAL,
   THERMAL_TRIP_TYPE_MAX,
@@ -163,6 +164,7 @@ struct thermal_zone_trip_s
 struct thermal_zone_params_s
 {
   FAR const char *gov_name;
+  int passive_delay;
   int polling_delay;
   FAR const struct thermal_zone_trip_s *trips;
   int num_trips;


### PR DESCRIPTION
> **Pick from https://github.com/apache/nuttx/pull/15994, https://github.com/apache/nuttx/pull/15811 and https://github.com/apache/nuttx/pull/15891**
## Summary
1. Add support for passive trip point.
    Spliting `THERMAL_NORMAL` to `THERMAL_ACTIVE` and `THERMAL_PASSIVE`, to support different update intervals for thermal zone, mainly for low-power.
    Can save power by reducing times the worker was invoked.
2. Add another dummy passive cooling device.
    For case that CPUFreq was not enabled.


## Impact
drivers/thermal

## Testing
1. Selftest PASSED with `sim:thermal`
Init
    ```
    root@3cadb4421218:/workspace/nuttx# ./nuttx
    [    0.000000] thermal_register_governor: Register governor step_wise
    [    0.000000] thermal_register_governor: Default governor step_wise registered!
    [    0.000000] thermal_cooling_device_register: Registered cooling device passive_dev
    [    0.000000] thermal_cooling_device_register: Registered cooling device fan0
    [    0.000000] thermal_zone_device_register: Set governor of zone cpu-thermal to step_wise.
    [    0.000000] zone_bind_cooling: Adding instance zdev:cpu-thermal cdev:passive_dev h: 1 l: 0 t:2
    [    0.000000] zone_bind_cooling: Adding instance zdev:cpu-thermal cdev:fan0 h:16 l: 0 t:1
    [    0.000000] thermal_zone_device_register: Registered zone device cpu-thermal
    [    0.000000] dummy_zdev_get_temp: dummy_zdev_get_temp
    
    NuttShell (NSH)
    nsh> cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:48 t:2 h:1 l:0 c:passive_dev s:0|(invalid)
    z:cpu-thermal t:48 t:1 h:16 l:0 c:fan0 s:0|(invalid)
    ```
    Passive to Active (see timestamp 96.330364, the interval changed from 4 sec to 2 sec after reached "active" trip)
    ```
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:68 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:68 t:1 h:16 l:0 c:fan0 s:0|(invalid)
    nsh> [   84.290252] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:65 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:65 t:1 h:16 l:0 c:fan0 s:0|(invalid)
    nsh> [   88.310378] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:70 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:70 t:1 h:16 l:0 c:fan0 s:0|(invalid)
    nsh> [   92.320361] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:67 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:67 t:1 h:16 l:0 c:fan0 s:0|(invalid)
    nsh> [   96.330364] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:72 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:72 t:1 h:16 l:0 c:fan0 s:1|1
    nsh> [   98.340141] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:69 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:69 t:1 h:16 l:0 c:fan0 s:1|1
    nsh> [  100.360367] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:74 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:74 t:1 h:16 l:0 c:fan0 s:2|2
    nsh> [  102.380351] dummy_zdev_get_temp: dummy_zdev_get_temp
    cat /proc/thermal/cpu-thermal
    z:cpu-thermal t:71 t:2 h:1 l:0 c:passive_dev s:1|1
    z:cpu-thermal t:71 t:1 h:16 l:0 c:fan0 s:2|2
    ```

2. CI
