### PR TITLE
rpmsg: fix rpmsg dead lock and ns bind race condition problem

### DIFF
--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -29,6 +29,7 @@
 #include <metal/sys.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
+#include <nuttx/rwsem.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/rpmsg/rpmsg.h>
 
@@ -70,7 +71,7 @@ static int rpmsg_dev_ioctl(FAR struct file *filep, int cmd,
 static METAL_DECLARE_LIST(g_rpmsg_cb);
 static METAL_DECLARE_LIST(g_rpmsg);
 
-static rmutex_t g_rpmsg_lock = NXRMUTEX_INITIALIZER;
+static rw_semaphore_t g_rpmsg_lock = RWSEM_INITIALIZER;
 
 static const struct file_operations g_rpmsg_dev_ops =
 {
@@ -237,7 +238,9 @@ int rpmsg_register_callback(FAR void *priv,
   cb->ns_match       = ns_match;
   cb->ns_bind        = ns_bind;
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_write(&g_rpmsg_lock);
+  metal_list_add_tail(&g_rpmsg_cb, &cb->node);
+  downgrade_write(&g_rpmsg_lock);
   metal_list_for_each(&g_rpmsg, node)
     {
       FAR struct rpmsg_s *rpmsg =
@@ -281,8 +284,7 @@ again:
        nxrmutex_unlock(&rpmsg->lock);
     }
 
-  metal_list_add_tail(&g_rpmsg_cb, &cb->node);
-  nxrmutex_unlock(&g_rpmsg_lock);
+  up_read(&g_rpmsg_lock);
 
   return 0;
 }
@@ -296,7 +298,7 @@ void rpmsg_unregister_callback(FAR void *priv,
   FAR struct metal_list *node;
   FAR struct metal_list *pnode;
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_write(&g_rpmsg_lock);
   metal_list_for_each(&g_rpmsg_cb, node)
     {
       FAR struct rpmsg_cb_s *cb =
@@ -314,6 +316,7 @@ void rpmsg_unregister_callback(FAR void *priv,
         }
     }
 
+  downgrade_write(&g_rpmsg_lock);
   if (device_destroy)
     {
       metal_list_for_each(&g_rpmsg, pnode)
@@ -328,7 +331,7 @@ void rpmsg_unregister_callback(FAR void *priv,
         }
     }
 
-  nxrmutex_unlock(&g_rpmsg_lock);
+  up_read(&g_rpmsg_lock);
 }
 
 void rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
@@ -338,7 +341,7 @@ void rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
   FAR struct rpmsg_bind_s *bind;
   FAR struct metal_list *node;
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_read(&g_rpmsg_lock);
   metal_list_for_each(&g_rpmsg_cb, node)
     {
       FAR struct rpmsg_cb_s *cb =
@@ -349,14 +352,12 @@ void rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
           rpmsg_bind_cb_t ns_bind = cb->ns_bind;
           FAR void *cb_priv = cb->priv;
 
-          nxrmutex_unlock(&g_rpmsg_lock);
+          up_read(&g_rpmsg_lock);
 
           ns_bind(rdev, cb_priv, name, dest);
           return;
         }
     }
-
-  nxrmutex_unlock(&g_rpmsg_lock);
 
   bind = kmm_malloc(sizeof(struct rpmsg_bind_s));
   if (bind == NULL)
@@ -370,6 +371,8 @@ void rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
   nxrmutex_lock(&rpmsg->lock);
   metal_list_add_tail(&rpmsg->bind, &bind->node);
   nxrmutex_unlock(&rpmsg->lock);
+
+  up_read(&g_rpmsg_lock);
 }
 
 void rpmsg_ns_unbind(FAR struct rpmsg_device *rdev,
@@ -400,7 +403,7 @@ void rpmsg_device_created(FAR struct rpmsg_s *rpmsg)
   FAR struct metal_list *node;
   FAR struct metal_list *tmp;
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_write(&g_rpmsg_lock);
   metal_list_for_each_safe(&g_rpmsg_cb, tmp, node)
     {
       FAR struct rpmsg_cb_s *cb =
@@ -413,7 +416,7 @@ void rpmsg_device_created(FAR struct rpmsg_s *rpmsg)
     }
 
   rpmsg->init = true;
-  nxrmutex_unlock(&g_rpmsg_lock);
+  up_write(&g_rpmsg_lock);
 
 #ifdef CONFIG_RPMSG_PING
   rpmsg_ping_init(rpmsg->rdev, &rpmsg->ping);
@@ -450,7 +453,9 @@ void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg)
 
   /* Broadcast device_destroy to all registers */
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_write(&g_rpmsg_lock);
+  rpmsg->init = false;
+  downgrade_write(&g_rpmsg_lock);
   metal_list_for_each_safe(&g_rpmsg_cb, tmp, node)
     {
       FAR struct rpmsg_cb_s *cb =
@@ -462,7 +467,22 @@ void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg)
         }
     }
 
-  nxrmutex_unlock(&g_rpmsg_lock);
+  up_read(&g_rpmsg_lock);
+
+  /* Release all ept attached to current rpmsg device */
+
+  metal_list_for_each_safe(&rpmsg->rdev->endpoints, tmp, node)
+    {
+      ept = metal_container_of(node, struct rpmsg_endpoint, node);
+      if (ept->ns_unbind_cb)
+        {
+          ept->ns_unbind_cb(ept);
+        }
+      else
+        {
+          rpmsg_destroy_ept(ept);
+        }
+    }
 }
 
 int rpmsg_register(FAR const char *path, FAR struct rpmsg_s *rpmsg,
@@ -490,18 +510,18 @@ int rpmsg_register(FAR const char *path, FAR struct rpmsg_s *rpmsg,
 
   /* Add priv to list */
 
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_write(&g_rpmsg_lock);
   metal_list_add_tail(&g_rpmsg, &rpmsg->node);
-  nxrmutex_unlock(&g_rpmsg_lock);
+  up_write(&g_rpmsg_lock);
 
   return ret;
 }
 
 void rpmsg_unregister(FAR const char *path, FAR struct rpmsg_s *rpmsg)
 {
-  nxrmutex_lock(&g_rpmsg_lock);
+  down_write(&g_rpmsg_lock);
   metal_list_del(&rpmsg->node);
-  nxrmutex_unlock(&g_rpmsg_lock);
+  up_write(&g_rpmsg_lock);
 
   nxrmutex_destroy(&rpmsg->lock);
   unregister_driver(path);
@@ -516,7 +536,7 @@ int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg)
 
   if (!up_interrupt_context())
     {
-      nxrmutex_lock(&g_rpmsg_lock);
+      down_read(&g_rpmsg_lock);
     }
 
   metal_list_for_each(&g_rpmsg, node)
@@ -536,7 +556,7 @@ int rpmsg_ioctl(FAR const char *cpuname, int cmd, unsigned long arg)
 
   if (!up_interrupt_context())
     {
-      nxrmutex_unlock(&g_rpmsg_lock);
+      up_read(&g_rpmsg_lock);
     }
 
   return ret;

--- a/include/nuttx/rwsem.h
+++ b/include/nuttx/rwsem.h
@@ -143,6 +143,19 @@ void down_write(FAR rw_semaphore_t *rwsem);
 void up_write(FAR rw_semaphore_t *rwsem);
 
 /****************************************************************************
+ * Name: downgrade_write
+ *
+ * Description:
+ *   Down grade write lock to read lock on a read-write-lock object.
+ *
+ * Input Parameters:
+ *   rwsem  - Pointer to the read-write-lock descriptor.
+ *
+ ****************************************************************************/
+
+void downgrade_write(FAR rw_semaphore_t *rwsem);
+
+/****************************************************************************
  * Name: init_rwsem
  *
  * Description:

--- a/sched/semaphore/sem_rw.c
+++ b/sched/semaphore/sem_rw.c
@@ -287,6 +287,33 @@ void up_write(FAR rw_semaphore_t *rwsem)
 }
 
 /****************************************************************************
+ * Name: downgrade_write
+ *
+ * Description:
+ *   Downgrade write lock to read lock on a read-write-lock object.
+ *
+ * Input Parameters:
+ *   rwsem  - Pointer to the read-write-lock descriptor.
+ *
+ ****************************************************************************/
+
+void downgrade_write(FAR rw_semaphore_t *rwsem)
+{
+  nxmutex_lock(&rwsem->protected);
+
+  DEBUGASSERT(rwsem->writer == 1);
+  DEBUGASSERT(rwsem->reader == 0);
+  DEBUGASSERT(rwsem->holder == _SCHED_GETTID());
+
+  rwsem->writer = 0;
+  rwsem->reader++;
+  rwsem->holder = RWSEM_NO_HOLDER;
+
+  up_wait(rwsem);
+  nxmutex_unlock(&rwsem->protected);
+}
+
+/****************************************************************************
  * Name: init_rwsem
  *
  * Description:


### PR DESCRIPTION

## Summary
If a ns_bind message come at between traverse g_rpmsg_cb and add g_rpmsg_cb list, the cb->node has not been added to the g_rpmsg_cb list yet. So rpmsg_ns_bind will not find this callback and not call the cb->ns_bind() to notify the rpmsg services.

## Impact
FIx rpmsg dead lock and ns bind race condition problem

## Testing
Test in vela


