### PR TITLE
Fix ILI9342C color inversion on esp32s3-box-3

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
@@ -420,6 +420,11 @@ static int ili9342c_sendgram(struct ili9341_lcd_s *lcd,
 
   lcdinfo("lcd:%p, wd=%p, nwords=%" PRIu32 "\n", lcd, wd, nwords);
 
+  for (size_t i = 0; i < nwords; i++)
+    {
+      ((uint16_t *)wd)[i] = __builtin_bswap16(wd[i]);
+    }
+
   SPI_SETBITS(priv->spi_dev, 16);
 
   SPI_CMDDATA(priv->spi_dev, SPIDEV_DISPLAY(0), false);


### PR DESCRIPTION
## Summary

When using the ILI9342C LCD on the esp32s3-box-3 development board, the displayed colors are inverted. After investigation, the issue is caused by a byte-order mismatch between the LCD controller (big-endian) and the LVGL graphics library (little-endian).

## Workaround Explanation

This is a temporary solution that manually converts the byte order of color data from little-endian (LVGL default) to big-endian (required by ILI9342C) before transmission.