### PR TITLE
checkpatch.sh: add -x option to auto-format Python files.

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -41,6 +41,7 @@ usage() {
   echo "-m Change-Id check in commit message (coupled with -g)"
   echo "-g <commit list>"
   echo "-f <file list>"
+  echo "-x format supported files (only .py, requires: pip install black)"
   echo "-  read standard input mainly used by git pre-commit hook as below:"
   echo "   git diff --cached | ./tools/checkpatch.sh -"
   echo "Where a <commit list> is any syntax supported by git for specifying git revision, see GITREVISIONS(7)"
@@ -67,6 +68,24 @@ is_cmake_file() {
     echo 1
   else
     echo 0
+  fi
+}
+
+format_file() {
+  if [ ${@##*.} == 'py' ]; then
+    if command -v black >/dev/null; then
+      echo "Auto-formatting Python file with black: $@"
+      setupcfg="${TOOLDIR}/../.github/linters/setup.cfg"
+      isort --settings-path "${setupcfg}" "$@"
+      black $@
+    else
+      echo "$@: error: black not found. Please install with: pip install black"
+      fail=1
+    fi
+  else
+    # TODO: extend for other file types in the future
+    echo "$@: error: format files type not implemented"
+    fail=1
   fi
 }
 
@@ -206,6 +225,9 @@ while [ ! -z "$1" ]; do
     ;;
   -u )
     encoding=1
+    ;;
+  -x )
+    check=format_file
     ;;
   -f )
     check=check_file


### PR DESCRIPTION
checkpatch.sh: add -x option to auto-format Python files.

Currently only .py files are supported. Non-Python files will report "format not implemented".

Signed-off-by: zhongzhijie1 <zhongzhijie1@xiaomi.com>