### PR TITLE
boards/xtensa/esp32s3/esp32s3-box: Fix ILI9342C color inversion

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include <debug.h>
 #include <errno.h>
+#include <endian.h>
 #include <sys/param.h>
 
 #include <nuttx/arch.h>
@@ -419,6 +420,11 @@ static int ili9342c_sendgram(struct ili9341_lcd_s *lcd,
   struct ili9342c_lcd_dev *priv = (struct ili9342c_lcd_dev *)lcd;
 
   lcdinfo("lcd:%p, wd=%p, nwords=%" PRIu32 "\n", lcd, wd, nwords);
+
+  for (uint32_t i = 0; i < nwords; i++)
+    {
+      ((uint16_t *)wd)[i] = swap16(wd[i]);
+    }
 
   SPI_SETBITS(priv->spi_dev, 16);
 


### PR DESCRIPTION
When using the ILI9342C LCD on the esp32s3-box-3 development board, the displayed colors are inverted.

add content

Manually converts the byte order of color data from little-endian to big-endian before transmission.