### PR TITLE
boards/xtensa/esp32s3/esp32s3-box: Fix ILI9342C color inversion

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <debug.h>
 #include <errno.h>
+#include <endian.h>
 #include <sys/param.h>
 
 #include <nuttx/arch.h>
@@ -421,6 +422,11 @@ static int ili9342c_sendgram(struct ili9341_lcd_s *lcd,
   struct ili9342c_lcd_dev *priv = (struct ili9342c_lcd_dev *)lcd;
 
   lcdinfo("lcd:%p, wd=%p, nwords=%" PRIu32 "\n", lcd, wd, nwords);
+
+  for (uint32_t i = 0; i < nwords; i++)
+    {
+      ((uint16_t *)wd)[i] = swap16(wd[i]);
+    }
 
   SPI_SETBITS(priv->spi_dev, 16);
 


### PR DESCRIPTION
When using the ILI9342C LCD on the esp32s3-box-3 development board, the displayed colors are inverted.

add content

Manually converts the byte order of color data from little-endian to big-endian before transmission.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

