### PR TITLE
build:add whole platform host build tools prebuilt

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -262,6 +262,11 @@ function setup_toolchain()
     export ARMLMD_LICENSE_FILE=${HOME}/.arm/ds/licenses/DS000-EV-31030.lic
   fi
 
+  # Host build-tools
+  if [ -d ${ROOTDIR}/prebuilts/build-tools/${SYSTEM}-${SYS_ARCH}/bin ]; then
+    export PATH=${ROOTDIR}/prebuilts/build-tools/${SYSTEM}-${SYS_ARCH}/bin:$PATH
+  fi
+
   # Generate compile database file compile_commands.json
   if type bear >/dev/null 2>&1; then
     # get version of bear


### PR DESCRIPTION
## Summary

This is a transitional solution for CI usage
before build.sh and emulator.sh is removed completely

## Impact

host build prebuilt tools

## Testing

CI build

