### PR TITLE
arch/arm: Add missing barriers.h

### DIFF
--- a/arch/arm/include/arm/barriers.h
+++ b/arch/arm/include/arm/barriers.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * arch/arm/include/arm/barriers.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_INCLUDE_ARM_BARRIERS_H
+#define __ARCH_ARM_INCLUDE_ARM_BARRIERS_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* ARM memory barriers */
+
+#define arm_dsb()  __asm__ __volatile__ ("dsb " : : : "memory")
+#define arm_isb()  __asm__ __volatile__ ("isb " : : : "memory")
+#define arm_dmb()  __asm__ __volatile__ ("dmb " : : : "memory")
+
+#define UP_DSB()  arm_dsb()
+#define UP_ISB()  arm_isb()
+#define UP_DMB()  arm_dmb()
+
+#endif /* __ARCH_ARM_INCLUDE_ARM_BARRIERS_H */


### PR DESCRIPTION
This commit adds the missing `barriers.h` for arm.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

add  the missing `barriers.h` for arm.

## Impact

NA

## Testing

NA

