### PR TITLE
RR-SCHED: in smp we get the wrong next tcb

### DIFF
--- a/sched/sched/sched_roundrobin.c
+++ b/sched/sched/sched_roundrobin.c
@@ -127,6 +127,7 @@ static int nxsched_roundrobin_handler(FAR void *cookie)
 uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
                                     bool noswitches)
 {
+  FAR struct tcb_s *ptcb;  /* Pointer to the next ready-to-run TCB */
   uint32_t ret;
   int decr;
 
@@ -180,8 +181,13 @@ uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
            * give that task a shot.
            */
 
-          if (tcb->flink &&
-              tcb->flink->sched_priority >= tcb->sched_priority)
+#ifdef CONFIG_SMP
+          ptcb = (FAR struct tcb_s *)dq_peek(list_readytorun());
+#else
+          ptcb = tcb->flink;
+#endif
+          if (ptcb &&
+              ptcb->sched_priority >= tcb->sched_priority)
             {
               FAR struct tcb_s *rtcb = this_task();
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

in smp, the tcb->flink is always empty, so we fix this bug.

## Impact

smp sched

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

