### PR TITLE
RR-SCHED: in smp we get the wrong next tcb

### DIFF
--- a/sched/sched/sched_roundrobin.c
+++ b/sched/sched/sched_roundrobin.c
@@ -35,6 +35,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/clock.h>
 
+#include "sched.h"
 #include "sched/sched.h"
 
 #if CONFIG_RR_INTERVAL > 0
@@ -179,9 +180,10 @@ uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
            * it is the same priority, then we need to relinquish the CPU and
            * give that task a shot.
            */
-
-          if (tcb->flink &&
-              tcb->flink->sched_priority >= tcb->sched_priority)
+          FAR struct tcb_s *ready_rtcb = (FAR struct tcb_s *)list_readytorun()->head;
+          if ((tcb->flink &&
+              tcb->flink->sched_priority >= tcb->sched_priority) ||
+              (ready_rtcb && ready_rtcb->sched_priority >= tcb->sched_priority))
             {
               FAR struct tcb_s *rtcb = this_task();
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

in smp,tcb->flink is empty,so we fix this bug.

## Impact

smp sched

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

