### PR TITLE
RR-SCHED: in smp we get the wrong next tcb

### DIFF
--- a/sched/sched/sched_roundrobin.c
+++ b/sched/sched/sched_roundrobin.c
@@ -168,6 +168,9 @@ uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
         }
       else
         {
+          FAR struct tcb_s *ready_rtcb =
+          (FAR struct tcb_s *)list_readytorun()->head;
+
           /* Reset the timeslice. */
 
           tcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
@@ -180,8 +183,10 @@ uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
            * give that task a shot.
            */
 
-          if (tcb->flink &&
-              tcb->flink->sched_priority >= tcb->sched_priority)
+          if ((tcb->flink &&
+              tcb->flink->sched_priority >= tcb->sched_priority) ||
+              (ready_rtcb &&
+              ready_rtcb->sched_priority >= tcb->sched_priority))
             {
               FAR struct tcb_s *rtcb = this_task();
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

in smp, fix tcb->flink may empty

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

