### PR TITLE
WIP: fix coredump contains wrong registers

### DIFF
--- a/arch/arm/src/arm/arm_dataabort.c
+++ b/arch/arm/src/arm/arm_dataabort.c
@@ -68,7 +68,9 @@
 #ifdef CONFIG_LEGACY_PAGING
 void arm_dataabort(uint32_t *regs, uint32_t far, uint32_t fsr)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   struct tcb_s *tcb = this_task();
+
 #ifdef CONFIG_LEGACY_PAGING
   uint32_t *savestate;
 
@@ -79,6 +81,11 @@ void arm_dataabort(uint32_t *regs, uint32_t far, uint32_t fsr)
   savestate = up_current_regs();
 #endif
   up_set_current_regs(regs);
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
 #ifdef CONFIG_LEGACY_PAGING
   /* In the NuttX on-demand paging implementation, only the read-only, .text
@@ -153,6 +160,13 @@ segfault:
 
 void arm_dataabort(uint32_t *regs)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
+
   /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */

--- a/arch/arm/src/armv7-a/arm_dataabort.c
+++ b/arch/arm/src/armv7-a/arm_dataabort.c
@@ -67,6 +67,7 @@
 #ifdef CONFIG_LEGACY_PAGING
 uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
   struct tcb_s *tcb = this_task();
   uint32_t *savestate;
 
@@ -76,6 +77,11 @@ uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 
   savestate = up_current_regs();
   up_set_current_regs(regs);
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
 
   /* In the NuttX on-demand paging implementation, only the read-only, .text
    * section is paged.  However, the ARM compiler generated PC-relative data
@@ -148,6 +154,13 @@ segfault:
 
 uint32_t *arm_dataabort(uint32_t *regs, uint32_t dfar, uint32_t dfsr)
 {
+  struct tcb_s **running_task = &g_running_tasks[this_cpu()];
+
+  if (*running_task != NULL)
+    {
+      (*running_task)->xcp.regs = regs;
+    }
+
   /* Save the saved processor context in current_regs where it can be
    * accessed for register dumps and possibly context switching.
    */


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Coredump will use tcb->xcp.regs, but it's not updated in data abort. This patch fixes it by save registers the moment data abort occurs to running_task.

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

