### PR TITLE
fs/pseudofs: Add `pseudofile_create_from()`

### DIFF
--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -437,6 +437,7 @@ int foreach_inode(foreach_inode_t handler, FAR void *arg);
 
 int dir_allocate(FAR struct file *filep, FAR const char *relpath);
 
+#ifdef CONFIG_PSEUDOFS_FILE
 /****************************************************************************
  * Name: pseudofile_create
  *
@@ -446,9 +447,21 @@ int dir_allocate(FAR struct file *filep, FAR const char *relpath);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_PSEUDOFS_FILE
 int pseudofile_create(FAR struct inode **node, FAR const char *path,
                       mode_t mode);
+
+/****************************************************************************
+ * Name: pseudofile_create_from
+ *
+ * Description:
+ *   Create the pseudo-file with specified path, buf, size and mode.
+ *   The content pointed to by buf will not be modified. When modifications
+ *   are required, memory will be allocated for storage.
+ *
+ ****************************************************************************/
+
+int pseudofile_create_from(FAR const char *path,
+                           FAR const void *buf, size_t size, mode_t mode);
 #endif
 
 /****************************************************************************

--- a/fs/vfs/fs_pseudofile.c
+++ b/fs/vfs/fs_pseudofile.c
@@ -55,6 +55,12 @@ struct fs_pseudofile_s
   bool unlinked;
 #endif
   FAR char *content;
+
+  /* Mark the memory for the content is set externally and is not managed by
+   * the pseudofile.
+   */
+
+  bool ext;
 };
 
 /****************************************************************************
@@ -139,7 +145,11 @@ static void pseudofile_remove(FAR struct fs_pseudofile_s *pf)
 {
   nxmutex_unlock(&pf->lock);
   nxmutex_destroy(&pf->lock);
-  fs_heap_free(pf->content);
+  if (!pf->ext)
+    {
+      fs_heap_free(pf->content);
+    }
+
   fs_heap_free(pf);
 }
 
@@ -176,16 +186,22 @@ static int pseudofile_expand(FAR struct inode *node,
   FAR struct fs_pseudofile_s *pf = node->i_private;
   FAR void *tmp;
 
-  if (pf->content && fs_heap_malloc_size(pf->content) >= size)
+  if (!pf->ext && pf->content && fs_heap_malloc_size(pf->content) >= size)
     {
       node->i_size = size;
       return 0;
     }
 
-  tmp = fs_heap_realloc(pf->content, 1 << LOG2_CEIL(size));
+  tmp = fs_heap_realloc(pf->ext ? NULL : pf->content, 1 << LOG2_CEIL(size));
   if (tmp == NULL)
     {
       return -ENOMEM;
+    }
+
+  if (pf->ext)
+    {
+      memcpy(tmp, pf->content, node->i_size);
+      pf->ext = false;
     }
 
   pf->content = tmp;
@@ -327,6 +343,7 @@ static int pseudofile_mmap(FAR struct file *filep,
   if (map->offset >= 0 && map->offset < node->i_size &&
       map->length != 0 && map->offset + map->length <= node->i_size)
     {
+      pseudofile_expand(node, node->i_size);
       map->vaddr = pf->content + map->offset;
       map->munmap = pseudofile_munmap;
       map->priv.p = (FAR void *)node;
@@ -397,6 +414,12 @@ static int pseudofile_truncate(FAR struct file *filep, off_t length)
     {
       FAR void *tmp;
 
+      if (pf->ext)
+        {
+          node->i_size = length;
+          goto out;
+        }
+
       tmp = fs_heap_realloc(pf->content, length);
       if (tmp == NULL)
         {
@@ -451,28 +474,23 @@ static int pseudofile_unlink(FAR struct inode *node)
 }
 #endif
 
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: pseudofile_create
- *
- * Description:
- *   Create the pseudo-file with specified path and mode, and alloc inode
- *   of this pseudo-file.
- *
- ****************************************************************************/
-
-int pseudofile_create(FAR struct inode **node, FAR const char *path,
-                      mode_t mode)
+static int pseudofile_do_create(FAR struct inode **node,
+                                FAR const char *path,
+                                FAR const void *buf, size_t size,
+                                mode_t mode)
 {
   FAR struct fs_pseudofile_s *pf;
+  FAR struct inode *inode;
   int ret;
 
-  if (node == NULL || path == NULL)
+  if (path == NULL)
     {
       return -EINVAL;
+    }
+
+  if (node == NULL)
+    {
+      node = &inode;
     }
 
   pf = fs_heap_zalloc(sizeof(struct fs_pseudofile_s));
@@ -493,6 +511,12 @@ int pseudofile_create(FAR struct inode **node, FAR const char *path,
   (*node)->i_flags = 1;
   (*node)->u.i_ops = &g_pseudofile_ops;
   (*node)->i_private = pf;
+  if (buf && size)
+    {
+      pf->ext = true;
+      pf->content = (FAR char *)buf;
+      (*node)->i_size = size;
+    }
 
   atomic_fetch_add(&(*node)->i_crefs, 1);
 
@@ -507,6 +531,41 @@ reserve_err:
   nxmutex_destroy(&pf->lock);
   fs_heap_free(pf);
   return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pseudofile_create
+ *
+ * Description:
+ *   Create the pseudo-file with specified path and mode, and alloc inode
+ *   of this pseudo-file.
+ *
+ ****************************************************************************/
+
+int pseudofile_create(FAR struct inode **node, FAR const char *path,
+                      mode_t mode)
+{
+  return pseudofile_do_create(node, path, NULL, 0, mode);
+}
+
+/****************************************************************************
+ * Name: pseudofile_create_from
+ *
+ * Description:
+ *   Create the pseudo-file with specified path, buf, size and mode.
+ *   The content pointed to by buf will not be modified. When modifications
+ *   are required, memory will be allocated for storage.
+ *
+ ****************************************************************************/
+
+int pseudofile_create_from(FAR const char *path,
+                           FAR const void *buf, size_t size, mode_t mode)
+{
+  return pseudofile_do_create(NULL, path, buf, size, mode);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Add `pseudofile_create_from()` for creating the pseudo-file with specified path, const buf, size and mode.

The rcS of NSH or the init.rc of Init depends on the FS(file system), yet the code size required for the FS's functions and (persistent) data cannot be ignored. For instance, in scenarios involving only small files like init scripts, enabling the FS independently and creating an image for it may consume an excessive amount of code size. 

@xiaoxiang781216  has proposed an excellent idea: storing init scripts in a lightweight pseudofs. The functionality of pseudofs is already fully developed; when this patch is not included, a pseudo file can be created from a buffer using the following logic:
```C
/* For logical demonstration only; checks for return values and other items are omitted. */

FAR const char *init_rc = 
  "on init\n"
  "    start console";

int fd = open("/etc/init.d/init.rc", O_WRONLY | O_CREAT);

write(fd, init_rc, strlen(init_rc) + 1);

close(fd);
```
This patch is mainly used for: ① simplifying the usage steps; ② supporting writing operations; ③ save memory.
```C
FAR const char *init_rc = 
  "on init\n"
  "    start console";

pseudofile_create_from("/etc/init.d/init.rc", (char *)init_rc, strlen(init_rc) + 1, 0444);
```
## Impact
Add `pseudofile_create_from()` for creating the pseudo-file with specified path, const buf, size and mode.
Depends on `CONFIG_PSEUDOFS_FILE=y`

## Testing
1. Selftest with Init componet passed
```
[    0.020000] [ 3] [ 0] init_main: Parsing /init.rc
[    0.020000] [ 3] [ 0] init_main: Line   1: 'on init'
[    0.020000] [ 3] [ 0] init_main: New section (on)
[    0.020000] [ 3] [ 0] init_main: Add action 0x404819a0(init) to manager 0x404812d8
[    0.020000] [ 3] [ 0] init_main: Line   2: '    start console'
```

2. CI