### PR TITLE
sem_wait/trywait: retry again if fail but old still same.

### DIFF
--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -154,11 +154,20 @@ int nxsem_trywait(FAR sem_t *sem)
   if (sem->flags & SEM_TYPE_MUTEX)
     {
       short old = 1;
-      if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem), &old, 0,
-                                                memory_order_acquire,
-                                                memory_order_relaxed))
+      while (true)
         {
-          return OK;
+          if (old != 1)
+            {
+              break;
+            }
+
+          if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem),
+                                                    &old, 0,
+                                                    memory_order_acquire,
+                                                    memory_order_relaxed))
+            {
+              return OK;
+            }
         }
 
       return -EAGAIN;

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -260,11 +260,20 @@ int nxsem_wait(FAR sem_t *sem)
   if (sem->flags & SEM_TYPE_MUTEX)
     {
       short old = 1;
-      if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem), &old, 0,
-                                                memory_order_acquire,
-                                                memory_order_relaxed))
+      while (true)
         {
-          return OK;
+          if (old != 1)
+            {
+              break;
+            }
+
+          if (atomic_compare_exchange_weak_explicit(NXSEM_COUNT(sem),
+                                                    &old, 0,
+                                                    memory_order_acquire,
+                                                    memory_order_relaxed))
+            {
+              return OK;
+            }
         }
     }
 #endif


### PR DESCRIPTION
## Summary
If atomic_try_cmpxchg_xxxx runs on LL/SC architectures (e.g.ARMv7, ARMv8, RISC-V), the weak CAS expands to a single LDREX/STREX pair.

If the CPU takes an IRQ/FIQ/SVC between the two instructions, hardware performs an implicit CLREX and the following STREX returns 1, therefore atomic_try_cmpxchg_xxxx return failure even though *addr* still holds the expected value.

So let's retry atomic_try_cmpxchg_xxxx in this case.

## Impact
Before patch, will abort by ostest especially if we disabled the tickless and a loop for try wait.
After patch, will no longer abort by try-wait case.

## Testing
CI-test, arm-v8m board test.

---
在ostest循环压测的时候如果没有开启tickless, 会偶现第一次 mutex init之后就wait失败，经过分析rootcause是部分arch的CAS指令会被中断打断。

修改之后问题不再复现

问题在 #267 同样被提及。

该patch用于修复该问题。后续patch会继续针对信号量/互斥量进行继续优化。