### PR TITLE
arch/tricore: modify to include the path of the header file

### DIFF
--- a/arch/tricore/src/common/tricore_internal.h
+++ b/arch/tricore/src/common/tricore_internal.h
@@ -36,7 +36,7 @@
 
 #  include <IfxCpu_reg.h>
 #  include <Ifx_Ssw_Compilers.h>
-#  include <Tricore/Compilers/Compilers.h>
+#  include <Compilers/Compilers.h>
 #  include <IfxCpu_Intrinsics.h>
 #endif
 

--- a/arch/tricore/src/common/tricore_main.c
+++ b/arch/tricore/src/common/tricore_main.c
@@ -28,7 +28,7 @@
 #include "Ifx_Types.h"
 #include "IfxCpu.h"
 
-#ifdef CONFIG_ARCH_CHIP_AURIX_TC48X
+#ifdef CONFIG_ARCH_CHIP_AURIX_TC4XX
 #  include "IfxWtu.h"
 #else
 #  include "IfxScuWdt.h"


### PR DESCRIPTION
The path of the latest illd library header files has changed, so the include paths need to be updated.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

The path of the latest illd library header files has changed, so the include paths need to be updated.

## Impact

N/A

## Testing

N/A

