### PR TITLE
ci: check.yml: checkout the current repository instead of apache/nuttx.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
           path: nuttx
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

The `Check` workflow was inherited verbatim from `apache/nuttx`, where its checkout step hard-codes `repository: apache/nuttx`. In that upstream context this works because the PR's `base.sha` naturally lives in `apache/nuttx`.

In `open-vela/nuttx` the same workflow is broken end-to-end: every PR's `base.sha` refers to a commit on `open-vela/nuttx` (typically `dev` or `dev-ai-contest-2026`), and that commit does not exist in `apache/nuttx`. The job therefore fails on the very first command after checkout:

```
fatal: Invalid revision range 59740c84b0a851a7bc6f15a6d6d07566b0bd17f3..HEAD
Process completed with exit code 128.
```

This affects **every** open-vela PR — e.g. #292, #293, #294, #291 — not just one branch, and renders the Check workflow useless across the project.

## Fix

Remove the hard-coded `repository: apache/nuttx` line.  `actions/checkout@v4` then falls back to its default of `${{ github.repository }}`, which on a `pull_request` event is the **base** repository (`open-vela/nuttx`). Combined with the existing `fetch-depth: 0` the entire history including the PR's base SHA is available, so the subsequent `git log ${base.sha}..HEAD` and `tools/checkpatch.sh` invocation operate on the open-vela commits that the PR actually proposes.

```diff
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
           path: nuttx
           fetch-depth: 0
```

This is the minimum change needed.  The rest of the job (matcher, venv, pip install, checkpatch invocation) is left untouched.

## Impact

- **Is new feature added?** NO — CI workflow correctness fix.
- **Impact on user?** NO.
- **Impact on build?** NO — only the Check workflow.
- **Impact on hardware?** NO.
- **Impact on documentation?** NO.
- **Impact on security?** NO — checking out the current repository is what every other workflow already does.
- **Impact on compatibility?** NO.

## Testing

Verified that the failure mode is identical across unrelated open-vela PRs:

| PR | Branch | Check fail message | Job link |
|---|---|---|---|
| #292 | esp32s3-eye-contest-2026 | `Invalid revision range 59740c84b0a8...` exit 128 | [job](https://github.com/open-vela/nuttx/actions/runs/26146321380) |
| #291 (closed) | a STM32 board PR | same error pattern | (historical) |

After this PR is merged, the Check workflow will resolve the `pull_request.base.sha` against `open-vela/nuttx`, where it actually exists, and `tools/checkpatch.sh` will analyse the real PR diff.  Before this PR, no open-vela PR's coding-style was actually checked by CI.

## Reference

- The hard-coded `repository: apache/nuttx` was introduced when the workflow was originally synced from upstream and never re-evaluated for the open-vela context.

## PR verification Self-Check

- [x] This PR introduces only one functional change.
- [x] I have updated all required description fields above.
- [x] My PR adheres to Contributing Guidelines and Documentation.
- [ ] My PR is still work in progress (not ready for review).
- [x] My PR is ready for review and can be safely merged into a codebase.
