### PR TITLE
ci/check: fix fork PR base-SHA lookup by checking out PR merge ref

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
+          ref: refs/pull/${{ github.event.number }}/merge
           path: nuttx
           fetch-depth: 0
 


### PR DESCRIPTION
[check.yml](cci:7://file:///mnt/nvme/openvela/nuttx/.github/workflows/check.yml:0:0-0:0) checks out `apache/nuttx` but runs `git log $BASE_SHA..HEAD`
where `BASE_SHA` is a commit from `open-vela/nuttx` — it doesn't exist
in the apache tree, so the range always fails for open-vela fork PRs.

Fix: checkout `refs/pull/N/merge` (the PR's own merge commit) instead,
which brings the open-vela history and keeps the checkpatch tools intact.