### PR TITLE
ci: check.yml: checkout the current repository instead of apache/nuttx

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
           path: nuttx
           fetch-depth: 0
 


### PR DESCRIPTION
The Check workflow was inherited from apache/nuttx with a hardcoded repository: apache/nuttx in the checkout step. The original intent was to align with upstream check rules, but since open-vela/nuttx has diverged and not kept in sync, the base.sha in every PR refers to a commit that does not exist in apache/nuttx, causing 'fatal: Invalid revision range' (exit 128).

Remove the hardcoded repository line so actions/checkout@v4 defaults to ${{ github.repository }} (open-vela/nuttx), ensuring checkpatch runs against the actual open-vela commits.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*


