### PR TITLE
Modify BOOT2CFLAGS for pico_platform includes

### DIFF
--- a/arch/arm/src/rp2040/boot2/Make.defs
+++ b/arch/arm/src/rp2040/boot2/Make.defs
@@ -37,10 +37,13 @@ BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/hardware_regs/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/hardware_base/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/common/pico_base_headers/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/boards/include
-BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/pico_platform/include
+BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/pico_platform/include					# pico-sdk <2.2.0
+BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_common/include		# pico-sdk >=2.2.0
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_compiler/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_sections/include
 BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_panic/include
+BOOT2CFLAGS += -Wl,--no-warn-rwx-segments
+BOOT2CFLAGS += -Wl,--build-id=none
 
 $(BOOT_STAGE2).S: %.S: %.bin
 	python3 $(BOOT2DIR)/pad_checksum -s 0xffffffff $< $@


### PR DESCRIPTION
Fixes #300
## Summary

Fix two build issues in `arch/arm/src/rp2040/boot2/Make.defs`:

1. **Add pico-sdk 2.2.0 include path** — pico-sdk 2.2.0 reorganized platform headers and requires `src/rp2_common/pico_platform_common/include`. Without it, compilation fails with `fatal error: pico/platform.h: No such file or directory`.

2. **Disable `--build-id` for boot_stage2** — GCC 13.4.0's default specs contains `%{!r:--build-id}`, which adds a `.note.gnu.build-id` section (36 bytes) to the ELF. When `objcopy -Obinary` converts to raw binary, this inflates `rp2040_boot_stage2.bin` from 240 to 276 bytes, exceeding the 252-byte limit enforced by pico-sdk's `pad_checksum` script.

修复 `arch/arm/src/rp2040/boot2/Make.defs` 中的两个编译问题：

1. **添加 pico-sdk 2.2.0 头文件路径** — pico-sdk 2.2.0 重组了平台头文件目录，新增了必需的 `src/rp2_common/pico_platform_common/include` 路径，否则编译报错 `fatal error: pico/platform.h: No such file or directory`。

2. **禁用 boot_stage2 的 `--build-id`** — GCC 13.4.0 的默认 specs 包含 `%{!r:--build-id}`，会在 ELF 中生成 `.note.gnu.build-id` 节（36 字节）。`objcopy -Obinary` 转换时会包含该节，使 `rp2040_boot_stage2.bin` 从 240 字节膨胀到 276 字节，超过 pico-sdk 的 `pad_checksum` 脚本要求的 252 字节上限。

## Changes

```makefile
BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2040/pico_platform/include              # pico-sdk <2.2.0
BOOT2CFLAGS += -I$(PICO_SDK_PATH)/src/rp2_common/pico_platform_common/include   # pico-sdk >=2.2.0
BOOT2CFLAGS += -Wl,--no-warn-rwx-segments
BOOT2CFLAGS += -Wl,--build-id=none
```

## Test

```bash
export PICO_SDK_PATH=/path/to/pico-sdk
./build.sh nuttx/boards/arm/rp2040/raspberrypi-pico/configs/usbnsh -j16
```

Build succeeds, `rp2040_boot_stage2.bin` is 240 bytes (within 252-byte limit), `nuttx.uf2` generated.

编译成功，`rp2040_boot_stage2.bin` 为 240 字节（在 252 字节限制内），`nuttx.uf2` 正常生成。