### PR TITLE
Documentation/risc-v: fix title underline length for Zicfilp section.

### DIFF
--- a/Documentation/platforms/risc-v/common/index.rst
+++ b/Documentation/platforms/risc-v/common/index.rst
@@ -162,7 +162,7 @@ This extension helps protect against Return-Oriented Programming (ROP) and Jump-
 Programming (JOP) attacks by adding hardware checks for indirect branch targets.
 
 Zicfilp Extension Basics
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Zicfilp extension provides:
 


### PR DESCRIPTION
## Summary

The `Zicfilp Extension Basics` section title (24 chars) in
`Documentation/platforms/risc-v/common/index.rst:164` had a 23-char
`^^^^^...` underline. Sphinx rejects this strictly:

```
Warning, treated as error:
Documentation/platforms/risc-v/common/index.rst:165:
Title underline too short.
make: *** [Makefile:47: html] Error 2
```

This single missing `^` causes the `build-html` CI job to fail on
**every PR** that runs against `dev-ai-contest-2026`, including
#292 / #293 / #294.

## Impact

- Unblocks `build-html` CI for the entire branch.
- After this lands, #294 (anonymous hyperlink fix) will be the only
  remaining `build-html` blocker resolved — together they make the
  documentation pipeline fully green.
- The fix is a strict 1-character pad on the underline; semantics
  of the section are unchanged.

## Testing

- Visually verified title (24 chars) == underline (24 chars) ✅
- `./tools/checkpatch.sh -g HEAD` → exit 0 ✅
- Scanned the whole file for other underline-too-short issues — only
  this one ✅

## Self-Check

- [x] Atomic single-file fix
- [x] Commit subject ends with `.` (per openvela convention)
- [x] `Signed-off-by` present
- [x] Targeted at `dev-ai-contest-2026`
- [x] Sphinx warning fully resolved