### PR TITLE
xtensa/esp32: guard null esp_timer handles

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wireless.c
+++ b/arch/xtensa/src/esp32/esp32_wireless.c
@@ -1061,6 +1061,11 @@ int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
+
   rt_timer_start(rt_timer, timeout_us, false);
 
   return 0;
@@ -1085,6 +1090,11 @@ int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
+
   rt_timer_start(rt_timer, period, true);
 
   return 0;
@@ -1108,6 +1118,11 @@ int32_t esp_timer_stop(esp_timer_handle_t timer)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
+
   rt_timer_stop(rt_timer);
 
   return 0;
@@ -1130,6 +1145,11 @@ int32_t esp_timer_stop(esp_timer_handle_t timer)
 int32_t esp_timer_delete(esp_timer_handle_t timer)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
+
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
 
   rt_timer_delete(rt_timer);
 

--- a/arch/xtensa/src/esp32s3/esp32s3_wireless.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wireless.c
@@ -1050,6 +1050,11 @@ int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
+
   esp32s3_rt_timer_start(rt_timer, timeout_us, false);
 
   return 0;
@@ -1074,6 +1079,11 @@ int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
+
   esp32s3_rt_timer_start(rt_timer, period, true);
 
   return 0;
@@ -1097,6 +1107,11 @@ int32_t esp_timer_stop(esp_timer_handle_t timer)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
+
   esp32s3_rt_timer_stop(rt_timer);
 
   return 0;
@@ -1119,6 +1134,11 @@ int32_t esp_timer_stop(esp_timer_handle_t timer)
 int32_t esp_timer_delete(esp_timer_handle_t timer)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
+
+  if (rt_timer == NULL)
+    {
+      return -1;
+    }
 
   esp32s3_rt_timer_delete(rt_timer);
 


### PR DESCRIPTION
## Summary

Add NULL handle checks to the ESP timer wrapper APIs for ESP32 and ESP32-S3.

The affected wrappers now return failure when called with a NULL timer handle instead of passing the NULL pointer down to the rt_timer helpers.

## Impact

- arch/xtensa/src/esp32/esp32_wireless.c
- arch/xtensa/src/esp32s3/esp32s3_wireless.c

This is a defensive robustness fix for invalid timer handles. Valid timer handles keep the same behavior.

## Testing

1. `./tools/checkpatch.sh -g HEAD~1..HEAD`
2. CI.