### PR TITLE
drivers/lcd/lcd_dev: Add poll support

### DIFF
--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -69,6 +69,8 @@ static int lcddev_open(FAR struct file *filep);
 static int lcddev_close(FAR struct file *filep);
 static int lcddev_ioctl(FAR struct file *filep, int cmd,
                         unsigned long arg);
+static int lcddev_poll(FAR struct file *filep, FAR struct pollfd *fds,
+                        bool setup);
 
 /****************************************************************************
  * Private Data
@@ -82,6 +84,9 @@ static const struct file_operations g_lcddev_fops =
   NULL,         /* write */
   NULL,         /* seek */
   lcddev_ioctl, /* ioctl */
+  NULL,         /* mmap */
+  NULL,         /* truncate */
+  lcddev_poll,  /* poll */
 };
 
 /****************************************************************************
@@ -393,6 +398,29 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
     }
 
   return ret;
+}
+
+/****************************************************************************
+ * Name: lcddev_poll
+ *
+ * Description:
+ *   Poll the LCD device. LCD is always ready for writing.
+ *
+ ****************************************************************************/
+
+static int lcddev_poll(FAR struct file *filep, FAR struct pollfd *fds,
+                       bool setup)
+{
+  if (setup)
+    {
+      fds->revents |= (fds->events & POLLOUT);
+      if (fds->revents != 0)
+        {
+          poll_notify(&fds, 1, POLLOUT);
+        }
+    }
+
+  return OK;
 }
 
 /****************************************************************************


### PR DESCRIPTION
Implement the poll method in g_lcddev_fops so that applications can register poll events on the LCD device fd. The LCD is always ready for writing, so setup requests immediately report POLLOUT via poll_notify.

This is required by LVGL's libuv mode (CONFIG_LV_USE_NUTTX_LIBUV=y), which QuickApp relies on. That mode uses uv_poll to register poll events on the LCD fd to drive display refresh. Without a poll implementation, libuv enters an inconsistent internal state and triggers a Data abort crash.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

