### PR TITLE
boards/esp32s3: add ES7210 support for Korvo-2

### DIFF
--- a/boards/xtensa/esp32s3/common/src/Make.defs
+++ b/boards/xtensa/esp32s3/common/src/Make.defs
@@ -58,6 +58,10 @@ ifeq ($(CONFIG_AUDIO_ES8311),y)
   CSRCS += esp32s3_es8311.c
 endif
 
+ifeq ($(CONFIG_AUDIO_ES7210),y)
+  CSRCS += esp32s3_es7210.c
+endif
+
 ifeq ($(CONFIG_SENSORS_BMP180),y)
   CSRCS += esp32s3_board_bmp180.c
 endif

--- a/boards/xtensa/esp32s3/common/src/esp32s3_es7210.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_es7210.c
@@ -1,0 +1,125 @@
+/****************************************************************************
+ * boards/xtensa/esp32s3/common/src/esp32s3_es7210.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/audio/audio.h>
+#include <nuttx/audio/es7210.h>
+#include <nuttx/audio/i2s.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "esp32s3_i2c.h"
+#include "esp32s3_i2s.h"
+
+#if defined(CONFIG_ESP32S3_I2S) && defined(CONFIG_AUDIO_ES7210)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct es7210_lower_s g_es7210_lower;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s3_es7210_initialize
+ *
+ * Description:
+ *   Configure and register the ES7210 4-channel ADC as the audio capture
+ *   device /dev/audio/pcm_in0.
+ *
+ * Input Parameters:
+ *   i2c_port - The I2C port used by the device
+ *   i2c_addr - The I2C address used by the device
+ *   i2c_freq - The I2C frequency used by the device
+ *   i2s_port - The I2S port used by the device
+ *
+ * Returned Value:
+ *   Zero is returned on success.  Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int esp32s3_es7210_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
+                              int i2s_port)
+{
+  struct audio_lowerhalf_s *es7210;
+  struct i2s_dev_s *i2s;
+  struct i2c_master_s *i2c;
+  int ret;
+
+  audinfo("i2c_port %d, i2c_addr %d, i2c_freq %d, i2s_port %d\n",
+          i2c_port, i2c_addr, i2c_freq, i2s_port);
+
+  i2s = esp32s3_i2sbus_initialize(i2s_port);
+  if (i2s == NULL)
+    {
+      auderr("ERROR: Failed to initialize I2S%d\n", i2s_port);
+      return -ENODEV;
+    }
+
+#ifdef CONFIG_AUDIO_I2SCHAR
+  ret = i2schar_register(i2s, i2s_port);
+  if (ret < 0 && ret != -EEXIST)
+    {
+      auderr("ERROR: i2schar_register failed: %d\n", ret);
+      return ret;
+    }
+#endif
+
+  i2c = esp32s3_i2cbus_initialize(i2c_port);
+  if (i2c == NULL)
+    {
+      auderr("ERROR: Failed to initialize I2C%d\n", i2c_port);
+      return -ENODEV;
+    }
+
+  g_es7210_lower.address = i2c_addr;
+  g_es7210_lower.frequency = i2c_freq;
+
+  es7210 = es7210_initialize(i2c, i2s, &g_es7210_lower);
+  if (es7210 == NULL)
+    {
+      auderr("ERROR: Failed to initialize the ES7210\n");
+      return -ENODEV;
+    }
+
+  ret = audio_register("pcm_in0", es7210);
+  if (ret < 0)
+    {
+      auderr("ERROR: Failed to register /dev/audio/pcm_in0: %d\n", ret);
+      return ret;
+    }
+
+  return OK;
+}
+
+#endif /* CONFIG_ESP32S3_I2S && CONFIG_AUDIO_ES7210 */

--- a/boards/xtensa/esp32s3/common/src/esp32s3_es8311.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_es8311.c
@@ -69,6 +69,7 @@ static struct es8311_lower_s g_es8311_lower[2];
  *   i2c_addr  - The I2C address used by the device
  *   i2c_freq  - The I2C frequency used for the device
  *   i2s_port  - The I2S port used for the device
+ *   enable_input - Register the ES8311 input device when true
  *
  * Returned Value:
  *   Zero is returned on success.  Otherwise, a negated errno value is
@@ -77,7 +78,7 @@ static struct es8311_lower_s g_es8311_lower[2];
  ****************************************************************************/
 
 int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
-                            int i2s_port)
+                              int i2s_port, bool enable_input)
 {
   struct audio_lowerhalf_s *es8311;
   struct i2s_dev_s *i2s;
@@ -176,6 +177,12 @@ int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
         {
           auderr("ERROR: Failed to register /dev/pcm0 device: %d\n", ret);
           goto errout;
+        }
+
+      if (!enable_input)
+        {
+          initialized = true;
+          return OK;
         }
 
       /* Now we can use this I2S interface to initialize the ES8311 input

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/include/board.h
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/include/board.h
@@ -46,4 +46,9 @@
 #  define ES8311_I2C_ADDR       0x18
 #endif
 
+#ifdef CONFIG_AUDIO_ES7210
+#  define ES7210_I2C_FREQ       100000
+#  define ES7210_I2C_ADDR       0x40
+#endif
+
 #endif /* __BOARDS_XTENSA_ESP32S3_ESP32S3_KORVO_2_INCLUDE_BOARD_H */

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h
@@ -29,6 +29,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 /****************************************************************************
@@ -104,6 +105,7 @@ int board_spiflash_init(void);
  *   i2c_addr  - The I2C address used by the device
  *   i2c_freq  - The I2C frequency used for the device
  *   i2s_port  - The I2S port used for the device
+ *   enable_input - Register the ES8311 input device when true
  *
  * Returned Value:
  *   Zero is returned on success.  Otherwise, a negated errno value is
@@ -113,7 +115,12 @@ int board_spiflash_init(void);
 
 #ifdef CONFIG_AUDIO_ES8311
 int esp32s3_es8311_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
-                            int i2s_port);
+                              int i2s_port, bool enable_input);
+#endif
+
+#ifdef CONFIG_AUDIO_ES7210
+int esp32s3_es7210_initialize(int i2c_port, uint8_t i2c_addr, int i2c_freq,
+                              int i2s_port);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
@@ -144,9 +144,19 @@ int esp32s3_bringup(void)
 {
   int ret;
 #if (defined(CONFIG_ESP32S3_I2S0) && !defined(CONFIG_AUDIO_CS4344) && \
-     !defined(CONFIG_AUDIO_ES8311)) || defined(CONFIG_ESP32S3_I2S1)
+     !defined(CONFIG_AUDIO_ES8311) && !defined(CONFIG_AUDIO_ES7210)) || \
+    defined(CONFIG_ESP32S3_I2S1)
   bool i2s_enable_tx;
   bool i2s_enable_rx;
+#endif
+#if defined(CONFIG_ESP32S3_I2S) && defined(CONFIG_ESP32S3_I2S0) && \
+    defined(CONFIG_AUDIO_ES8311)
+  bool es8311_enable_input = true;
+#endif
+
+#if defined(CONFIG_ESP32S3_I2S) && defined(CONFIG_ESP32S3_I2S0) && \
+    defined(CONFIG_AUDIO_ES8311) && defined(CONFIG_AUDIO_ES7210)
+  es8311_enable_input = false;
 #endif
 
 #if defined(CONFIG_ESP32S3_SPIRAM) && \
@@ -314,13 +324,14 @@ int esp32s3_bringup(void)
   esp32s3_gpiowrite(SPEAKER_ENABLE_GPIO, true);
 
   ret = esp32s3_es8311_initialize(ESP32S3_I2C0, ES8311_I2C_ADDR,
-                                  ES8311_I2C_FREQ, ESP32S3_I2S0);
+                                  ES8311_I2C_FREQ, ESP32S3_I2S0,
+                                  es8311_enable_input);
   if (ret != OK)
     {
       syslog(LOG_ERR, "Failed to initialize ES8311 audio: %d\n", ret);
     }
 
-#    else
+#    elif !defined(CONFIG_AUDIO_ES7210)
 #      ifdef CONFIG_ESP32S3_I2S0_TX
   i2s_enable_tx = true;
 #      else
@@ -342,6 +353,19 @@ int esp32s3_bringup(void)
     }
 
 #    endif /* CONFIG_AUDIO_ES8311 */
+
+#    ifdef CONFIG_AUDIO_ES7210
+
+  /* Configure ES7210 audio capture on I2C0 and I2S0 */
+
+  ret = esp32s3_es7210_initialize(ESP32S3_I2C0, ES7210_I2C_ADDR,
+                                  ES7210_I2C_FREQ, ESP32S3_I2S0);
+  if (ret != OK)
+    {
+      syslog(LOG_ERR, "Failed to initialize ES7210 audio: %d\n", ret);
+    }
+
+#    endif /* CONFIG_AUDIO_ES7210 */
 #  endif /* CONFIG_ESP32S3_I2S0 */
 
 #  ifdef CONFIG_ESP32S3_I2S1


### PR DESCRIPTION
Initialize the ES7210 capture codec on the Korvo-2 and register it as pcm_in0 while preserving ES8311 playback.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

Dependency: replace this line with the merged ES7210 lower-half PR link before
submission.

## Summary

Connect the ES7210 four-channel ADC lower-half driver to the
ESP32-S3-Korvo-2 board.

The board glue initializes I2C and I2S, supplies the codec address and bus
frequency, and registers the capture device as /dev/audio/pcm_in0. When
I2SCHAR is enabled, it also exposes the shared I2S diagnostic node.

When ES8311 playback and ES7210 capture are enabled together, the board
registers ES8311 output only and lets ES7210 own the input device. This avoids
two codecs registering competing pcm_in devices while preserving ES8311
playback.

## Impact

- User impact: Adds ES7210 capture support to ESP32-S3-Korvo-2.
- Build impact: Adds one board source when CONFIG_AUDIO_ES7210=y.
- Hardware impact: Uses I2C0, I2S0, address 0x40, and a 100 kHz I2C bus.
- API impact: Extends the board-local ES8311 initializer with an input-enable
  argument; it has no external public ABI.
- Security impact: None.
- Linker impact: None; no linker script or custom section is added.

## Testing

- Host: Linux x86_64.
- Compiler: xtensa-esp32s3-elf-gcc.
- Target: ESP32-S3-Korvo-2.
- Clean build and final link completed successfully with the ES7210
  lower-half dependency.
- Flash verification completed on the target board.
- Booted to NSH and verified:
  - /dev/audio/pcm0
  - /dev/audio/pcm_in0
  - /dev/i2schar0
- Recorded a valid 3-second, 48 kHz, 16-bit, four-channel PCM stream.
- git diff --check and NuttX checkpatch/nxstyle passed, including the complete
  new board source.
