### PR TITLE
boards/esp32s3: add ST7789 LCD support for Korvo-2

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/Kconfig
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/Kconfig
@@ -5,5 +5,15 @@
 
 if ARCH_BOARD_ESP32S3_KORVO_2
 
-endif # ARCH_BOARD_ESP32S3_KORVO_2
+config ESP32S3_KORVO_2_LCD
+	bool "Enable ESP32-S3-Korvo-2 LCD"
+	default n
+	select ESP32S3_SPI2
+	select SPI_CMDDATA
+	select LCD
+	select LCD_DEV
+	select LCD_ST7789
+	---help---
+		Enable the ST7789V 240x280 LCD connected through SPI2.
 
+endif # ARCH_BOARD_ESP32S3_KORVO_2

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/Make.defs
@@ -39,6 +39,10 @@ ifeq ($(CONFIG_ESP32S3_SPI),y)
 CSRCS += esp32s3_board_spi.c
 endif
 
+ifeq ($(CONFIG_ESP32S3_KORVO_2_LCD),y)
+CSRCS += esp32s3_board_lcd.c
+endif
+
 ifeq ($(CONFIG_ESP32S3_TWAI),y)
 CSRCS += esp32s3_twai.c
 endif
@@ -50,4 +54,3 @@ endif
 DEPPATH += --dep-path board
 VPATH += :board
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board
-

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h
@@ -49,6 +49,14 @@
 #  define SPEAKER_ENABLE_GPIO  48
 #endif
 
+/* Display (ST7789V over SPI2) **********************************************/
+
+#define KORVO_2_DISPLAY_SPI         2
+#define KORVO_2_DISPLAY_DC          2
+#define KORVO_2_DISPLAY_BACKLIGHT   14
+
+#define GPIO_LCD_DC                 KORVO_2_DISPLAY_DC
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -78,6 +86,30 @@
  ****************************************************************************/
 
 int esp32s3_bringup(void);
+
+/****************************************************************************
+ * Name: board_lcd_initialize
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_KORVO_2_LCD
+int board_lcd_initialize(void);
+#endif
+
+/****************************************************************************
+ * Name: board_lcd_getdev
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_KORVO_2_LCD
+struct lcd_dev_s *board_lcd_getdev(int lcddev);
+#endif
+
+/****************************************************************************
+ * Name: board_lcd_uninitialize
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_KORVO_2_LCD
+void board_lcd_uninitialize(void);
+#endif
 
 /****************************************************************************
  * Name: board_spiflash_init

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_board_lcd.c
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_board_lcd.c
@@ -1,0 +1,128 @@
+/****************************************************************************
+ * boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_board_lcd.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/st7789.h>
+#include <nuttx/spi/spi.h>
+
+#include "esp32s3_gpio.h"
+#include "esp32s3_spi.h"
+
+#include "esp32s3-korvo-2.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the ST7789V display connected to SPI2.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  esp32s3_configgpio(KORVO_2_DISPLAY_DC, OUTPUT);
+  esp32s3_configgpio(KORVO_2_DISPLAY_BACKLIGHT, OUTPUT);
+  esp32s3_gpiowrite(KORVO_2_DISPLAY_BACKLIGHT, true);
+
+  g_spidev = esp32s3_spibus_initialize(KORVO_2_DISPLAY_SPI);
+  if (g_spidev == NULL)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n",
+             KORVO_2_DISPLAY_SPI);
+      return -ENODEV;
+    }
+
+  g_lcd = st7789_lcdinitialize(g_spidev);
+  if (g_lcd == NULL)
+    {
+      lcderr("ERROR: st7789_lcdinitialize() failed\n");
+      return -ENODEV;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: board_lcd_getdev
+ *
+ * Description:
+ *   Return the LCD object for the requested display number.
+ *
+ * Input Parameters:
+ *   devno - Display number.
+ *
+ * Returned Value:
+ *   LCD device pointer on success; NULL on failure.
+ *
+ ****************************************************************************/
+
+struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  if (g_lcd == NULL)
+    {
+      lcderr("ERROR: Failed to bind SPI port %d to LCD %d\n",
+             KORVO_2_DISPLAY_SPI, devno);
+      return NULL;
+    }
+
+  lcdinfo("SPI port %d bound to LCD %d\n", KORVO_2_DISPLAY_SPI, devno);
+  return g_lcd;
+}
+
+/****************************************************************************
+ * Name: board_lcd_uninitialize
+ *
+ * Description:
+ *   Turn off the LCD.
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  if (g_lcd != NULL)
+    {
+      g_lcd->setpower(g_lcd, 0);
+    }
+}

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
@@ -28,6 +28,9 @@
 
 #include <stdio.h>
 #include <fcntl.h>
+#ifdef CONFIG_LCD_DEV
+#  include <nuttx/lcd/lcd_dev.h>
+#endif
 #include <unistd.h>
 #include <syslog.h>
 #include <sys/stat.h>
@@ -453,6 +456,22 @@ int esp32s3_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: board_capture_initialize failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_ESP32S3_KORVO_2_LCD
+  ret = board_lcd_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: board_lcd_initialize() failed: %d\n", ret);
+    }
+  else
+    {
+      ret = lcddev_register(0);
+      if (ret < 0)
+        {
+          syslog(LOG_ERR, "ERROR: lcddev_register() failed: %d\n", ret);
+        }
     }
 #endif
 


### PR DESCRIPTION
Add the Korvo-2 SPI, command/data, and backlight glue needed to register the existing ST7789 lower-half as lcd0.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Add ESP32-S3-Korvo-2 board glue for the existing NuttX ST7789 LCD
lower-half driver.

The change adds a board Kconfig option, selects the required SPI command/data
and LCD components, initializes SPI2 plus the DC and backlight GPIOs, and
registers the display as /dev/lcd0. Initialization failures are returned
without registering an invalid LCD device.

The supported panel area is 240x280 with the board-specific offset and SPI
configuration supplied by the selected config.

## Impact

- User impact: Adds /dev/lcd0 when the Korvo-2 LCD option is enabled.
- Build impact: Adds one board source under the new Kconfig option.
- Hardware impact: Uses SPI2 and Korvo-2 LCD DC, CS, and backlight GPIOs.
- API/ABI impact: None.
- Security impact: None.
- Compatibility: Existing configurations are unchanged when the option is
  disabled.

The current Korvo-2 OV3660 wiring conflicts with the LCD on GPIO14 and GPIO47.
Camera and LCD must therefore not be enabled together in a default config.

## Testing

- Host: Linux x86_64.
- Compiler: xtensa-esp32s3-elf-gcc.
- Target: ESP32-S3-Korvo-2 with ST7789, SPI2, LCD device, NX, and nxlines.
- Clean build, final link, image generation, and target flash completed.
- Booted to NSH and verified /dev/lcd0.
- Ran nxlines; NX connected and reported a 280x240 landscape resolution,
  then continuously submitted line vectors.
- git diff --check and NuttX checkpatch/nxstyle passed, including the complete
  new board source.