### PR TITLE
drivers/input: fix FT5X06 Y-axis threshold check

### DIFF
--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -481,7 +481,7 @@ static ssize_t ft5x06_sample(FAR struct ft5x06_dev_s *priv, FAR char *buffer,
                   deltay = -deltay;
                 }
 
-              if (deltax < CONFIG_FT5X06_THRESHX)
+              if (deltay < CONFIG_FT5X06_THRESHY)
                 {
                   /* Ignore... no significant change in Y either */
 


### PR DESCRIPTION
## Summary

Fix the FT5X06 Y-axis movement filter to compare `deltay` against `CONFIG_FT5X06_THRESHY`.

This is a backport of apache/nuttx@c9fd44a0eca1564f1ece9c2918b755fa4c2f180d.

## Impact

Valid Y-axis touch movement is no longer suppressed based on the X-axis delta and threshold. There are no API or configuration changes.

## Testing

- `git diff --check`
- Compared the one-line change with the Apache NuttX upstream fix
- Build not run; the local audit checkout contains only the files required for this backport
