### PR TITLE
fix(boards/stm32h750b-dk): invert user LED polarity for active-low hardware

### DIFF
--- a/boards/arm/stm32h7/stm32h750b-dk/src/stm32_autoleds.c
+++ b/boards/arm/stm32h7/stm32h750b-dk/src/stm32_autoleds.c
@@ -54,6 +54,13 @@ static const uint32_t g_ledmap[BOARD_NLEDS] =
   GPIO_LED_RED,
 };
 
+static const bool g_ledpol[BOARD_NLEDS] =
+{
+  LD1_ACTIVE_HIGH,
+  LD2_ACTIVE_HIGH,
+  LD3_ACTIVE_HIGH,
+};
+
 static bool g_initialized;
 
 /****************************************************************************
@@ -62,9 +69,9 @@ static bool g_initialized;
 
 static void phy_set_led(int led, bool state)
 {
-  /* Active High */
+  /* LEDs have mixed polarity; see LDx_ACTIVE_HIGH in stm32h750b-dk.h */
 
-  stm32_gpiowrite(g_ledmap[led], state);
+  stm32_gpiowrite(g_ledmap[led], state == g_ledpol[led]);
 }
 
 /****************************************************************************

--- a/boards/arm/stm32h7/stm32h750b-dk/src/stm32_userleds.c
+++ b/boards/arm/stm32h7/stm32h750b-dk/src/stm32_userleds.c
@@ -57,6 +57,13 @@ static const uint32_t g_ledcfg[BOARD_NLEDS] =
   GPIO_LED_RED,
 };
 
+static const bool g_ledpol[BOARD_NLEDS] =
+{
+  LD1_ACTIVE_HIGH,
+  LD2_ACTIVE_HIGH,
+  LD3_ACTIVE_HIGH,
+};
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -100,7 +107,7 @@ void board_userled(int led, bool ledon)
 {
   if ((unsigned)led < ARRAYSIZE(g_ledcfg))
     {
-      stm32_gpiowrite(g_ledcfg[led], ledon);
+      stm32_gpiowrite(g_ledcfg[led], ledon == g_ledpol[led]);
     }
 }
 
@@ -123,7 +130,8 @@ void board_userled_all(uint32_t ledset)
 
   for (i = 0; i < ARRAYSIZE(g_ledcfg); i++)
     {
-      stm32_gpiowrite(g_ledcfg[i], (ledset & (1 << i)) != 0);
+      stm32_gpiowrite(g_ledcfg[i],
+                      ((ledset & (1 << i)) != 0) == g_ledpol[i]);
     }
 }
 

--- a/boards/arm/stm32h7/stm32h750b-dk/src/stm32h750b-dk.h
+++ b/boards/arm/stm32h7/stm32h750b-dk/src/stm32h750b-dk.h
@@ -75,10 +75,16 @@
 
 /* LED */
 
+/* Physical LED polarity: 1 = active high, 0 = active low */
+#define LD1_ACTIVE_HIGH 0
+#define LD2_ACTIVE_HIGH 0
+#define LD3_ACTIVE_HIGH 1
+
+/* Initial output level keeps every LED off at power-on */
 #define GPIO_LD1       (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_50MHz | \
-                        GPIO_OUTPUT_CLEAR | GPIO_PORTI | GPIO_PIN13)
+                        GPIO_OUTPUT_SET | GPIO_PORTI | GPIO_PIN13)
 #define GPIO_LD2       (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_50MHz | \
-                        GPIO_OUTPUT_CLEAR | GPIO_PORTJ | GPIO_PIN2)
+                        GPIO_OUTPUT_SET | GPIO_PORTJ | GPIO_PIN2)
 #define GPIO_LD3       (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_50MHz | \
                         GPIO_OUTPUT_CLEAR | GPIO_PORTD | GPIO_PIN3)
 


### PR DESCRIPTION
## Summary

STM32H750B-DK 板载用户 LED 为混合极性：LD1/LD2 低电平点亮，LD3 高电平点亮。原 BSP 按统一 active-high 直写 GPIO，导致 `board_userled(led, true)` 在 LD1/LD2 上表现为熄灭。本次改为按每颗 LED 的物理极性表驱动写入，恢复 `board_userled` 的 "true = 点亮" 语义。

## Features

- 新增 `LD1/LD2/LD3_ACTIVE_HIGH` 极性宏，`board_userled` / `board_userled_all` 按极性表写入
- 同步修复 `CONFIG_ARCH_LEDS` 路径（`stm32_autoleds.c` 的 `phy_set_led`）
- 调整 `GPIO_LD1`/`GPIO_LD2` 初始输出电平，保证上电时所有 LED 处于熄灭状态

## Files

| 文件 | 说明 |
|------|------|
| boards/arm/stm32h7/stm32h750b-dk/src/stm32h750b-dk.h | 新增 LED 极性宏；修正 LD1/LD2 初始输出电平 |
| boards/arm/stm32h7/stm32h750b-dk/src/stm32_userleds.c | `board_userled` / `board_userled_all` 按极性表写入 |
| boards/arm/stm32h7/stm32h750b-dk/src/stm32_autoleds.c | `phy_set_led` 同步极性处理 |

## Testing

- stm32h750b-dk 最小配置编译通过（text+data ≈ 93KB，≤ 128KB 片内 Flash）
- 实机验证：`board_userled(..., true)` 点亮 LD1/LD2，`false` 熄灭；LD3 高电平点亮正常