### PR TITLE
arch/arm/bk7258: add Beken BK7258 SoC support (NSH on CPU0/UART0)

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -321,6 +321,16 @@ config ARCH_CHIP_NRF91
 		Nordic nRF91 architectures (ARM Cortex-M33 with integrated
 		LTE-M/NB-IoT modem and GNSS).
 
+config ARCH_CHIP_BK7258
+	bool "Beken BK7258"
+	select ARCH_CORTEXM33
+	select ARCH_HAVE_FPU
+	select ARM_HAVE_MPU_UNIFIED
+	depends on EXPERIMENTAL
+	---help---
+		Beken BK7258 Wi-Fi AI-SoC (dual-core Armv8-M STAR-MC1, up to
+		480MHz).  Initial support targets a single core (CPU0), non-SMP.
+
 config ARCH_CHIP_NUC1XX
 	bool "Nuvoton NUC100/120"
 	select ARCH_CORTEXM0
@@ -1116,6 +1126,7 @@ config ARCH_CHIP
 	default "max326xx"	if ARCH_CHIP_MAX326XX
 	default "moxart"	if ARCH_CHIP_MOXART
 	default "nrf52"		if ARCH_CHIP_NRF52
+	default "bk7258"	if ARCH_CHIP_BK7258
 	default "nrf53"		if ARCH_CHIP_NRF53
 	default "nrf91"		if ARCH_CHIP_NRF91
 	default "nuc1xx"	if ARCH_CHIP_NUC1XX
@@ -1579,6 +1590,9 @@ source "arch/arm/src/moxart/Kconfig"
 endif
 if ARCH_CHIP_NRF52
 source "arch/arm/src/nrf52/Kconfig"
+endif
+if ARCH_CHIP_BK7258
+source "arch/arm/src/bk7258/Kconfig"
 endif
 if ARCH_CHIP_NRF53
 source "arch/arm/src/nrf53/Kconfig"

--- a/arch/arm/include/bk7258/chip.h
+++ b/arch/arm/include/bk7258/chip.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * arch/arm/include/bk7258/chip.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_INCLUDE_BK7258_CHIP_H
+#define __ARCH_ARM_INCLUDE_BK7258_CHIP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* NVIC system exception priorities (STAR-MC1, Armv8-M) */
+
+#define NVIC_SYSH_PRIORITY_MIN     0xe0  /* All bits[7:5] set = min priority */
+#define NVIC_SYSH_PRIORITY_DEFAULT 0x80  /* Midpoint default */
+#define NVIC_SYSH_PRIORITY_MAX     0x00  /* Zero = max priority */
+#define NVIC_SYSH_PRIORITY_STEP    0x20  /* Steps between priorities */
+
+#endif /* __ARCH_ARM_INCLUDE_BK7258_CHIP_H */

--- a/arch/arm/include/bk7258/irq.h
+++ b/arch/arm/include/bk7258/irq.h
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * arch/arm/include/bk7258/irq.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
+
+#ifndef __ARCH_ARM_INCLUDE_BK7258_IRQ_H
+#define __ARCH_ARM_INCLUDE_BK7258_IRQ_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+#  include <stdint.h>
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Processor Exceptions (vectors 0-15) */
+
+#define BK7258_IRQ_RESERVED    (0)  /* Reserved (CONFIG_DEBUG_FEATURES) */
+                                    /* Vector 0: Reset stack pointer value */
+                                    /* Vector 1: Reset (not handled as IRQ) */
+#define BK7258_IRQ_NMI         (2)  /* Vector 2:  NMI */
+#define BK7258_IRQ_HARDFAULT   (3)  /* Vector 3:  Hard fault */
+#define BK7258_IRQ_MEMFAULT    (4)  /* Vector 4:  MPU fault */
+#define BK7258_IRQ_BUSFAULT    (5)  /* Vector 5:  Bus fault */
+#define BK7258_IRQ_USAGEFAULT  (6)  /* Vector 6:  Usage fault */
+#define BK7258_IRQ_SECUREFAULT (7)  /* Vector 7:  Secure fault (Armv8-M TZ) */
+                                    /* Vectors 8-10: Reserved */
+#define BK7258_IRQ_SVCALL      (11) /* Vector 11: SVC call */
+#define BK7258_IRQ_DBGMONITOR  (12) /* Vector 12: Debug Monitor */
+                                    /* Vector 13: Reserved */
+#define BK7258_IRQ_PENDSV      (14) /* Vector 14: PendSV */
+#define BK7258_IRQ_SYSTICK     (15) /* Vector 15: SysTick */
+#define BK7258_IRQ_EXTINT      (16) /* Vector 16: First external interrupt */
+
+/* External interrupts (NVIC), from ARMINO icu_map.h (64 sources, GROUP0/1).
+ * NuttX IRQ number = BK7258_IRQ_EXTINT + INT_SRC index.
+ */
+
+#define BK7258_IRQ_DMA0        (BK7258_IRQ_EXTINT + 0)
+#define BK7258_IRQ_ENCP        (BK7258_IRQ_EXTINT + 1)
+#define BK7258_IRQ_ENCS        (BK7258_IRQ_EXTINT + 2)
+#define BK7258_IRQ_TIMER0      (BK7258_IRQ_EXTINT + 3)
+#define BK7258_IRQ_UART0       (BK7258_IRQ_EXTINT + 4)
+#define BK7258_IRQ_PWM0        (BK7258_IRQ_EXTINT + 5)
+#define BK7258_IRQ_I2C0        (BK7258_IRQ_EXTINT + 6)
+#define BK7258_IRQ_SPI0        (BK7258_IRQ_EXTINT + 7)
+#define BK7258_IRQ_SARADC      (BK7258_IRQ_EXTINT + 8)
+#define BK7258_IRQ_IRDA        (BK7258_IRQ_EXTINT + 9)
+#define BK7258_IRQ_SDIO        (BK7258_IRQ_EXTINT + 10)
+#define BK7258_IRQ_GDMA        (BK7258_IRQ_EXTINT + 11)
+#define BK7258_IRQ_LA          (BK7258_IRQ_EXTINT + 12)
+#define BK7258_IRQ_TIMER1      (BK7258_IRQ_EXTINT + 13)
+#define BK7258_IRQ_I2C1        (BK7258_IRQ_EXTINT + 14)
+#define BK7258_IRQ_UART1       (BK7258_IRQ_EXTINT + 15)
+#define BK7258_IRQ_UART2       (BK7258_IRQ_EXTINT + 16)
+#define BK7258_IRQ_SPI1        (BK7258_IRQ_EXTINT + 17)
+#define BK7258_IRQ_CAN         (BK7258_IRQ_EXTINT + 18)
+#define BK7258_IRQ_USB         (BK7258_IRQ_EXTINT + 19)
+#define BK7258_IRQ_QSPI0       (BK7258_IRQ_EXTINT + 20)
+#define BK7258_IRQ_CKMN        (BK7258_IRQ_EXTINT + 21)
+#define BK7258_IRQ_SBC         (BK7258_IRQ_EXTINT + 22)
+#define BK7258_IRQ_AUDIO       (BK7258_IRQ_EXTINT + 23)
+#define BK7258_IRQ_I2S0        (BK7258_IRQ_EXTINT + 24)
+#define BK7258_IRQ_JPEG_ENC    (BK7258_IRQ_EXTINT + 25)
+#define BK7258_IRQ_JPEG_DEC    (BK7258_IRQ_EXTINT + 26)
+#define BK7258_IRQ_LCD         (BK7258_IRQ_EXTINT + 27)
+#define BK7258_IRQ_DMA2D       (BK7258_IRQ_EXTINT + 28)
+#define BK7258_IRQ_GPIO        (BK7258_IRQ_EXTINT + 55)
+#define BK7258_IRQ_RTC         (BK7258_IRQ_EXTINT + 54)
+#define BK7258_IRQ_MAILBOX     (BK7258_IRQ_EXTINT + 63)
+
+/* Total number of external interrupts (INT_SRC 0..63) and total IRQs */
+
+#define BK7258_IRQ_NEXTINT     (64)
+#define NR_IRQS                (BK7258_IRQ_EXTINT + BK7258_IRQ_NEXTINT)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+typedef void (*vic_vector_t)(uint32_t *regs);
+#endif
+
+#endif /* __ARCH_ARM_INCLUDE_BK7258_IRQ_H */

--- a/arch/arm/src/bk7258/CMakeLists.txt
+++ b/arch/arm/src/bk7258/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# arch/arm/src/bk7258/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS bk7258_start.c bk7258_lowputc.c bk7258_irq.c bk7258_timerisr.c
+         bk7258_allocateheap.c bk7258_serial.c)
+
+# --- To be implemented (M2/M3) ---
+# list(APPEND SRCS bk7258_clockconfig.c bk7258_gpio.c)
+
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/arm/src/bk7258/Kconfig
+++ b/arch/arm/src/bk7258/Kconfig
@@ -1,0 +1,82 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+comment "BK7258 Configuration Options"
+
+# Chip family identifier (active when ARCH_CHIP_BK7258 is selected by the
+# choice in arch/arm/Kconfig).
+
+if ARCH_CHIP_BK7258
+
+menu "BK7258 Peripheral Selection"
+
+config BK7258_UART0
+	bool "UART0 (console, on-board CH340)"
+	default y
+	---help---
+		Enable UART0 (base 0x44820000).  When NuttX runs as the CPU0 main
+		core, UART0 is directly attached to the on-board CH340 and serves
+		as both the bootROM download port and the NSH console.
+
+config BK7258_UART1
+	bool "UART1"
+	default n
+	---help---
+		Enable UART1 (base 0x45830000).
+
+config BK7258_UART2
+	bool "UART2"
+	default n
+
+endmenu # BK7258 Peripheral Selection
+
+# UART base address used for low-level console output (bk7258_lowputc.c).
+
+config BK7258_CONSOLE_UART_BASE
+	hex
+	default 0x44820000 if BK7258_UART0
+	default 0x45830000 if BK7258_UART1
+	default 0x44820000
+
+config BK7258_CONSOLE_BAUD
+	int "Console baud rate"
+	default 115200
+
+menu "BK7258 Debug (SWD bring-up)"
+
+config BK7258_DEBUG_FAULT_SPIN
+	bool "Spin (while(1)) in fault handlers for SWD inspection"
+	default n
+	---help---
+		Bare-metal SWD debug aid: replace the HardFault/MemManage/BusFault/
+		UsageFault handlers with "emit a marker then spin in while(1)",
+		instead of the default NuttX _alert/PANIC (which may fault again or
+		produce no output before the OS is up).
+
+		The core then stops at the fault site, and the exception frame
+		stacked by hardware (r0-r3, r12, LR, PC, xPSR) is preserved on the
+		MSP, so a DAP-Link + OpenOCD halt can read PC/CFSR to locate the
+		crash.  This mirrors the Beken jlink example of adding while(1) in
+		the fault handler and inspecting the stack after suspend.
+
+		It also enables the configurable Mem/Bus/Usage faults individually
+		so they do not escalate to HardFault, letting OpenOCD tell which
+		class of fault occurred.
+
+		Turn this off once SWD bring-up is done to restore the default
+		NuttX fault handling.
+
+config BK7258_DEBUG_FAULT_SPIN_MARK
+	bool "Emit a marker string before spinning"
+	default y
+	depends on BK7258_DEBUG_FAULT_SPIN
+	---help---
+		Print a "!!BKFAULT!!" marker to the console UART before spinning
+		(directly via arm_lowputc, independent of the OS).  If the serial
+		port works, the marker alone tells you a fault spin was entered.
+
+endmenu # BK7258 Debug
+
+endif # ARCH_CHIP_BK7258

--- a/arch/arm/src/bk7258/Make.defs
+++ b/arch/arm/src/bk7258/Make.defs
@@ -1,0 +1,34 @@
+############################################################################
+# arch/arm/src/bk7258/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# ARMv8-M common layer (STAR-MC1, Cortex-M33 compatible)
+include armv8-m/Make.defs
+
+# --- Implemented (M1) ---
+CHIP_CSRCS += bk7258_start.c
+CHIP_CSRCS += bk7258_lowputc.c
+CHIP_CSRCS += bk7258_irq.c
+CHIP_CSRCS += bk7258_timerisr.c
+CHIP_CSRCS += bk7258_allocateheap.c
+CHIP_CSRCS += bk7258_serial.c
+
+# --- To be implemented (M2/M3) ---
+# CHIP_CSRCS += bk7258_clockconfig.c  # DPLL 480MHz clock config
+# CHIP_CSRCS += bk7258_gpio.c         # GPIO / pin mux

--- a/arch/arm/src/bk7258/bk7258_allocateheap.c
+++ b/arch/arm/src/bk7258/bk7258_allocateheap.c
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_allocateheap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* The heap extends from the top of the idle stack to the end of the RAM
+ * data region.  CONFIG_RAM_START/SIZE are set in defconfig
+ * (0x28010000 / 336KB for the CPU0 app RAM window).
+ */
+
+#define BK7258_RAM_END (CONFIG_RAM_START + CONFIG_RAM_SIZE)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_allocate_heap
+ ****************************************************************************/
+
+void up_allocate_heap(void **heap_start, size_t *heap_size)
+{
+  *heap_start = (void *)g_idle_topstack;
+  *heap_size  = BK7258_RAM_END - g_idle_topstack;
+}

--- a/arch/arm/src/bk7258/bk7258_irq.c
+++ b/arch/arm/src/bk7258/bk7258_irq.c
@@ -1,0 +1,392 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_irq.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Porting reference: arch/arm/src/mps/mps_irq.c (generic armv8-m NVIC). */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+
+#include "ram_vectors.h"
+#include "arm_internal.h"
+#include "nvic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BK7258_IRQ_FIRST   BK7258_IRQ_EXTINT
+
+#define NVIC_ENA_OFFSET    (0)
+#define NVIC_CLRENA_OFFSET (NVIC_IRQ0_31_CLEAR - NVIC_IRQ0_31_ENABLE)
+
+#define DEFPRIORITY32      (NVIC_SYSH_PRIORITY_DEFAULT << 24 | \
+                            NVIC_SYSH_PRIORITY_DEFAULT << 16 | \
+                            NVIC_SYSH_PRIORITY_DEFAULT << 8  | \
+                            NVIC_SYSH_PRIORITY_DEFAULT)
+
+/* BK7258 SYS-level interrupt aggregator: besides the NVIC, a peripheral
+ * interrupt must also be enabled here to reach CPU0's NVIC.  Each bit = the
+ * interrupt source number (same as the NVIC line): sources 0-31 at
+ * 0x44010080, sources 32-63 at 0x44010084.  (Measured: the UART RX
+ * interrupt was asserted on the UART side but never delivered because this
+ * step was missing.)
+ */
+
+#define BK7258_SYS_CPU0_INT_0_31_EN   0x44010080
+#define BK7258_SYS_CPU0_INT_32_63_EN  0x44010084
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_BK7258_DEBUG_FAULT_SPIN
+
+/* SWD debug aid: on a fault, expose the stacked exception frame pointer to
+ * a global so OpenOCD/gdb can read it directly.  context is the register
+ * frame saved by NuttX, whose REG_PC/REG_LR/REG_XPSR hold the fault site.
+ */
+
+volatile void *g_bk7258_fault_regs;
+
+/* bk7258_fault_spin: emit a marker then spin, preserving the fault site for
+ * SWD inspection.  Does not call _alert/PANIC (which may fault again or
+ * produce no output when the OS is not yet up).
+ */
+
+static int bk7258_fault_spin(int irq, void *context, void *arg)
+{
+#ifdef CONFIG_BK7258_DEBUG_FAULT_SPIN_MARK
+  const char *s = "\r\n!!BKFAULT!! irq=";
+#endif
+
+  g_bk7258_fault_regs = context;
+
+  up_irq_save();
+
+#ifdef CONFIG_BK7258_DEBUG_FAULT_SPIN_MARK
+  while (*s)
+    {
+      arm_lowputc(*s++);
+    }
+
+  /* Print the exception number (single decimal digit is enough:
+   * HardFault=3/Mem=4/Bus=5/Usage=6).
+   */
+
+  arm_lowputc('0' + (irq % 10));
+  arm_lowputc('\r');
+  arm_lowputc('\n');
+#endif
+
+  /* Spin here: the core stays put and the exception frame on the MSP is
+   * preserved for reading PC/CFSR after an SWD halt.
+   */
+
+  for (; ; )
+    {
+    }
+
+  return 0;
+}
+#endif /* CONFIG_BK7258_DEBUG_FAULT_SPIN */
+
+#ifdef CONFIG_DEBUG_FEATURES
+static int bk7258_nmi(int irq, void *context, void *arg)
+{
+  up_irq_save();
+  _err("PANIC!!! NMI received\n");
+  PANIC();
+  return 0;
+}
+
+static int bk7258_pendsv(int irq, void *context, void *arg)
+{
+  up_irq_save();
+  _err("PANIC!!! PendSV received\n");
+  PANIC();
+  return 0;
+}
+
+static int bk7258_reserved(int irq, void *context, void *arg)
+{
+  up_irq_save();
+  _err("PANIC!!! Reserved interrupt\n");
+  PANIC();
+  return 0;
+}
+#endif
+
+static inline void bk7258_prioritize_syscall(int priority)
+{
+  uint32_t regval;
+
+  /* SVCALL is system handler 11 */
+
+  regval  = getreg32(NVIC_SYSH8_11_PRIORITY);
+  regval &= ~NVIC_SYSH_PRIORITY_PR11_MASK;
+  regval |= (priority << NVIC_SYSH_PRIORITY_PR11_SHIFT);
+  putreg32(regval, NVIC_SYSH8_11_PRIORITY);
+}
+
+static int bk7258_irqinfo(int irq, uintptr_t *regaddr, uint32_t *bit,
+                          uintptr_t offset)
+{
+  int n;
+
+  DEBUGASSERT(irq >= BK7258_IRQ_NMI && irq < NR_IRQS);
+
+  if (irq >= BK7258_IRQ_FIRST)
+    {
+      n        = irq - BK7258_IRQ_FIRST;
+      *regaddr = NVIC_IRQ_ENABLE(n) + offset;
+      *bit     = (uint32_t)0x1 << (n & 0x1f);
+    }
+  else
+    {
+      *regaddr = NVIC_SYSHCON;
+      if (irq == BK7258_IRQ_MEMFAULT)
+        {
+          *bit = NVIC_SYSHCON_MEMFAULTENA;
+        }
+      else if (irq == BK7258_IRQ_BUSFAULT)
+        {
+          *bit = NVIC_SYSHCON_BUSFAULTENA;
+        }
+      else if (irq == BK7258_IRQ_USAGEFAULT)
+        {
+          *bit = NVIC_SYSHCON_USGFAULTENA;
+        }
+      else if (irq == BK7258_IRQ_SYSTICK)
+        {
+          *regaddr = NVIC_SYSTICK_CTRL;
+          *bit = NVIC_SYSTICK_CTRL_ENABLE;
+        }
+      else
+        {
+          return -EINVAL;
+        }
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int up_prioritize_irq(int irq, int priority)
+{
+  uint32_t regaddr;
+  uint32_t regval;
+  int shift;
+
+  DEBUGASSERT(irq >= 0 && irq < NR_IRQS &&
+              (unsigned)priority <= NVIC_SYSH_PRIORITY_MIN);
+
+  if (irq < 16)
+    {
+      regaddr = NVIC_SYSH_PRIORITY(irq);
+      irq    -= 4;
+    }
+  else
+    {
+      irq    -= 16;
+      regaddr = NVIC_IRQ_PRIORITY(irq);
+    }
+
+  regval  = getreg32(regaddr);
+  shift   = ((irq & 3) << 3);
+  regval &= ~(0xff << shift);
+  regval |= (priority << shift);
+  putreg32(regval, regaddr);
+
+  return OK;
+}
+
+void up_irqinitialize(void)
+{
+  uint32_t regaddr;
+  int num_priority_registers;
+  int i;
+
+  /* Disable all interrupts */
+
+  for (i = 0; i < NR_IRQS - BK7258_IRQ_FIRST; i += 32)
+    {
+      putreg32(0xffffffff, NVIC_IRQ_CLEAR(i));
+    }
+
+  putreg32((uint32_t)_vectors, NVIC_VECTAB);
+
+#ifdef CONFIG_ARCH_RAMVECTORS
+  arm_ramvec_initialize();
+#endif
+
+  /* Set all interrupts (and exceptions) to the default priority */
+
+  putreg32(DEFPRIORITY32, NVIC_SYSH4_7_PRIORITY);
+  putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
+  putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
+
+  num_priority_registers = (getreg32(NVIC_ICTR) + 1) * 8;
+
+  regaddr = NVIC_IRQ0_3_PRIORITY;
+  while (num_priority_registers--)
+    {
+      putreg32(DEFPRIORITY32, regaddr);
+      regaddr += 4;
+    }
+
+  /* Attach the SVCall and Hard Fault exception handlers */
+
+  irq_attach(BK7258_IRQ_SVCALL, arm_svcall, NULL);
+  irq_attach(BK7258_IRQ_HARDFAULT, arm_hardfault, NULL);
+
+  up_prioritize_irq(BK7258_IRQ_PENDSV, NVIC_SYSH_PRIORITY_MIN);
+  bk7258_prioritize_syscall(NVIC_SYSH_SVCALL_PRIORITY);
+
+#ifdef CONFIG_ARM_MPU
+  irq_attach(BK7258_IRQ_MEMFAULT, arm_memfault, NULL);
+  up_enable_irq(BK7258_IRQ_MEMFAULT);
+#endif
+
+#ifdef CONFIG_DEBUG_FEATURES
+  irq_attach(BK7258_IRQ_NMI, bk7258_nmi, NULL);
+#ifndef CONFIG_ARM_MPU
+  irq_attach(BK7258_IRQ_MEMFAULT, arm_memfault, NULL);
+#endif
+  irq_attach(BK7258_IRQ_BUSFAULT, arm_busfault, NULL);
+  irq_attach(BK7258_IRQ_USAGEFAULT, arm_usagefault, NULL);
+  irq_attach(BK7258_IRQ_PENDSV, bk7258_pendsv, NULL);
+  irq_attach(BK7258_IRQ_DBGMONITOR, arm_dbgmonitor, NULL);
+  irq_attach(BK7258_IRQ_RESERVED, bk7258_reserved, NULL);
+#endif
+
+#ifdef CONFIG_BK7258_DEBUG_FAULT_SPIN
+  /* SWD debug: override the default fault handlers above with the spinning
+   * handler (attached last, so it wins).  Also enable Mem/Bus/Usage fault
+   * individually so they do not escalate to HardFault -> OpenOCD can tell
+   * which class of fault it is.
+   */
+
+  irq_attach(BK7258_IRQ_HARDFAULT, bk7258_fault_spin, NULL);
+  irq_attach(BK7258_IRQ_MEMFAULT, bk7258_fault_spin, NULL);
+  irq_attach(BK7258_IRQ_BUSFAULT, bk7258_fault_spin, NULL);
+  irq_attach(BK7258_IRQ_USAGEFAULT, bk7258_fault_spin, NULL);
+  up_enable_irq(BK7258_IRQ_MEMFAULT);
+  up_enable_irq(BK7258_IRQ_BUSFAULT);
+  up_enable_irq(BK7258_IRQ_USAGEFAULT);
+#endif
+
+#ifndef CONFIG_SUPPRESS_INTERRUPTS
+  arm_color_intstack();
+  up_irq_enable();
+#endif
+}
+
+static void bk7258_sys_int_set(int irq, bool enable)
+{
+  uintptr_t reg;
+  uint32_t bit;
+  int src;
+
+  if (irq < BK7258_IRQ_EXTINT)
+    {
+      return;
+    }
+
+  src = irq - BK7258_IRQ_EXTINT;
+  if (src < 32)
+    {
+      reg = BK7258_SYS_CPU0_INT_0_31_EN;
+      bit = 1u << src;
+    }
+  else
+    {
+      reg = BK7258_SYS_CPU0_INT_32_63_EN;
+      bit = 1u << (src - 32);
+    }
+
+  if (enable)
+    {
+      putreg32(getreg32(reg) | bit, reg);
+    }
+  else
+    {
+      putreg32(getreg32(reg) & ~bit, reg);
+    }
+}
+
+void up_disable_irq(int irq)
+{
+  uintptr_t regaddr;
+  uint32_t regval;
+  uint32_t bit;
+
+  if (bk7258_irqinfo(irq, &regaddr, &bit, NVIC_CLRENA_OFFSET) == 0)
+    {
+      if (irq >= BK7258_IRQ_FIRST)
+        {
+          putreg32(bit, regaddr);
+          bk7258_sys_int_set(irq, false);
+        }
+      else
+        {
+          regval  = getreg32(regaddr);
+          regval &= ~bit;
+          putreg32(regval, regaddr);
+        }
+    }
+}
+
+void up_enable_irq(int irq)
+{
+  uintptr_t regaddr;
+  uint32_t regval;
+  uint32_t bit;
+
+  if (bk7258_irqinfo(irq, &regaddr, &bit, NVIC_ENA_OFFSET) == 0)
+    {
+      if (irq >= BK7258_IRQ_FIRST)
+        {
+          putreg32(bit, regaddr);
+          bk7258_sys_int_set(irq, true);
+        }
+      else
+        {
+          regval  = getreg32(regaddr);
+          regval |= bit;
+          putreg32(regval, regaddr);
+        }
+    }
+}
+
+void arm_ack_irq(int irq)
+{
+}

--- a/arch/arm/src/bk7258/bk7258_lowputc.c
+++ b/arch/arm/src/bk7258/bk7258_lowputc.c
@@ -1,0 +1,172 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_lowputc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include "arm_internal.h"
+#include "hardware/bk7258_uart.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Console defaults to UART0: the on-board CH340 is UART0 (bootROM DL_UART),
+ * so download and log share one cable.  NuttX runs as the CPU0 main core
+ * directly attached to this port.
+ */
+
+#ifndef CONFIG_BK7258_CONSOLE_UART_BASE
+#  define CONFIG_BK7258_CONSOLE_UART_BASE  BK7258_UART0_BASE
+#endif
+
+#ifndef CONFIG_BK7258_CONSOLE_BAUD
+#  define CONFIG_BK7258_CONSOLE_BAUD       115200
+#endif
+
+/* UART clock source = 26MHz XTAL (ARMINO: UART_CLOCK = CONFIG_XTAL_FREQ,
+ * default 26M).  Baud formula (ARMINO uart_ll):
+ *   baud = UART_CLK / (clk_div + 1)  =>  clk_div = UART_CLK / baud - 1
+ *   26000000 / 115200 = 225.69 -> clk_div = 225 (actual 115044, ~0.13%).
+ */
+
+#define BK7258_UART_CLK   26000000u
+#define BK7258_UART_DIV \
+  (((BK7258_UART_CLK + (CONFIG_BK7258_CONSOLE_BAUD / 2)) / \
+    CONFIG_BK7258_CONSOLE_BAUD) - 1)
+
+#define CONSOLE_BASE      CONFIG_BK7258_CONSOLE_UART_BASE
+
+/* --- Peripheral clock enable + GPIO pin mux ------------------------------
+ * As the CPU0 main core, NuttX must enable the UART peripheral clock itself
+ * and mux the TX/RX pins to the UART function (the bootloader may have torn
+ * them down at hand-off).  Registers from the ARMINO SDK:
+ *   Clock:  SYS_CPU_DEVICE_CLK_ENABLE @ 0x44010030 (UART0_CKEN = bit2)
+ *   Source: SYS_CLK_DIV_MODE1 @ 0x44010020 (cksel_uart0 = bit10, 0 = XTAL)
+ *   Pins:   system function select pins 8-15 @ 0x440100C4 (4 bits each,
+ *           value 0 = UART0)
+ *   Per pin: config @ 0x44000400 + n*4, bit6 = second (peripheral) function
+ */
+
+#define BK7258_SYS_CLK_EN        (BK7258_SYS_BASE + 0x30)      /* 0x44010030 */
+#  define SYS_CLK_EN_UART0       (1 << 2)
+#define BK7258_SYS_GPIO_FUNC8_15 (BK7258_SYS_BASE + 0xc4)      /* 0x440100C4 */
+#define BK7258_SYS_CLK_DIV_MODE1 (BK7258_SYS_BASE + 0x20)      /* 0x44010020 */
+#define BK7258_GPIO_CFG(n)       (BK7258_AON_GPIO_BASE + (n) * 4)
+#  define GPIO_CFG_SECOND_FUNC   (1 << 6)
+
+static void bk7258_putc_uart(uintptr_t base, char ch);
+
+/* Enable the UART0 clock + clock source (XTAL) and mux GPIO11/GPIO10 to
+ * UART0 TXD/RXD.  As the CPU0 main core the console uses UART0 (CH340); the
+ * bootloader may have torn UART0 down at hand-off, so re-enable the clock
+ * and re-mux the pins here, otherwise writing the FIFO emits no character.
+ * Pins: UART0_TX = GPIO11, UART0_RX = GPIO10 (function index 0).
+ */
+
+static void bk7258_uart0_hwsetup(void)
+{
+  /* 1) Enable the UART0 peripheral clock */
+
+  modifyreg32(BK7258_SYS_CLK_EN, 0, SYS_CLK_EN_UART0);
+
+  /* 2) UART0 clock source = XTAL 26M (cksel_uart0 = bit10, 0 = XTAL) */
+
+  modifyreg32(BK7258_SYS_CLK_DIV_MODE1, (1u << 10), 0);
+
+  /* 3) GPIO10 -> UART0_RXD [11:8], GPIO11 -> UART0_TXD [15:12], func 0 */
+
+  modifyreg32(BK7258_SYS_GPIO_FUNC8_15, (0xfu << 8) | (0xfu << 12), 0);
+
+  /* 4) Enable the second (peripheral) function on GPIO10/GPIO11 */
+
+  modifyreg32(BK7258_GPIO_CFG(10), 0, GPIO_CFG_SECOND_FUNC);
+  modifyreg32(BK7258_GPIO_CFG(11), 0, GPIO_CFG_SECOND_FUNC);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bk7258_lowsetup
+ ****************************************************************************/
+
+static void bk7258_uart_config(uintptr_t base)
+{
+  uint32_t cfg;
+
+  /* Do not soft reset: the bootloader has already configured UART0 and is
+   * transmitting normally (div=225, TX on).  A soft reset would clear its
+   * working TX state so TX no longer drains -> putc times out and drops
+   * characters (symptom: CH340 emits a single garbage byte).  Only ensure
+   * 8 data bits / baud / TX enable on top of the existing config; do not
+   * reset or override the bootloader's working clock/FIFO state.
+   */
+
+  cfg  = getreg32(BK7258_UART_CONFIG(base));
+  cfg &= ~(UART_CFG_DATA_BITS_MASK | UART_CFG_CLK_DIV_MASK);
+  cfg |= UART_CFG_DATA_BITS_8;
+  cfg |= (BK7258_UART_DIV << UART_CFG_CLK_DIV_SHIFT) & UART_CFG_CLK_DIV_MASK;
+  cfg |= UART_CFG_TX_ENABLE;
+
+  putreg32(cfg, BK7258_UART_CONFIG(base));
+}
+
+void bk7258_lowsetup(void)
+{
+  /* The CPU0 main core enables the UART0 (console = CH340) clock and pin
+   * mux itself (the bootloader may have torn it down at hand-off), then
+   * configures data bits / baud / TX.
+   */
+
+  bk7258_uart0_hwsetup();
+  bk7258_uart_config(BK7258_UART0_BASE);
+}
+
+/****************************************************************************
+ * Name: arm_lowputc
+ *
+ * Description:
+ *   Output one byte on the serial console (polled, blocking).
+ *
+ ****************************************************************************/
+
+static void bk7258_putc_uart(uintptr_t base, char ch)
+{
+  volatile int timeout = 200000;
+
+  while (((getreg32(BK7258_UART_FIFO_STATUS(base)) &
+           UART_FIFO_WR_READY) == 0) && (--timeout > 0))
+    {
+    }
+
+  putreg32((uint32_t)(uint8_t)ch, BK7258_UART_FIFO_PORT(base));
+}
+
+void arm_lowputc(char ch)
+{
+  bk7258_putc_uart(CONSOLE_BASE, ch);
+}

--- a/arch/arm/src/bk7258/bk7258_lowputc.h
+++ b/arch/arm/src/bk7258/bk7258_lowputc.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_lowputc.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_BK7258_BK7258_LOWPUTC_H
+#define __ARCH_ARM_SRC_BK7258_BK7258_LOWPUTC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bk7258_lowsetup
+ *
+ * Description:
+ *   Configure the console UART (UART0) to 115200 8N1 and enable TX.
+ *   Called once by the chip start-up path (bk7258_start) before
+ *   arm_lowputc() becomes usable.
+ *
+ ****************************************************************************/
+
+void bk7258_lowsetup(void);
+
+#endif /* __ARCH_ARM_SRC_BK7258_BK7258_LOWPUTC_H */

--- a/arch/arm/src/bk7258/bk7258_serial.c
+++ b/arch/arm/src/bk7258/bk7258_serial.c
@@ -1,0 +1,353 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_serial.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <nuttx/serial/serial.h>
+#include <arch/board/board.h>
+
+#include "arm_internal.h"
+#include "chip.h"
+#include "hardware/bk7258_uart.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Console = UART0 (on-board CH340).  NuttX runs as the CPU0 main core
+ * (replacing the ARMINO CP app); CPU0 owns UART0 and the bootloader has
+ * already set up its clock/pins.  115200 8N1, IRQ = EXTINT + 4.
+ */
+
+#define CONSOLE_BASE   BK7258_UART0_BASE
+#define CONSOLE_IRQ    BK7258_IRQ_UART0
+#define CONSOLE_BAUD   115200
+#define BK7258_UARTCLK 26000000u
+
+#ifndef CONFIG_UART0_RXBUFSIZE
+#  define CONFIG_UART0_RXBUFSIZE 256
+#endif
+#ifndef CONFIG_UART0_TXBUFSIZE
+#  define CONFIG_UART0_TXBUFSIZE 256
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct bk7258_uart_s
+{
+  uint32_t uartbase;
+  uint32_t baud;
+  uint8_t  irq;
+  uint8_t  ie;      /* Shadow of enabled interrupt bits */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int  bk7258_setup(struct uart_dev_s *dev);
+static void bk7258_shutdown(struct uart_dev_s *dev);
+static int  bk7258_attach(struct uart_dev_s *dev);
+static void bk7258_detach(struct uart_dev_s *dev);
+static int  bk7258_interrupt(int irq, void *context, void *arg);
+static int  bk7258_ioctl(struct file *filep, int cmd, unsigned long arg);
+static int  bk7258_receive(struct uart_dev_s *dev, unsigned int *status);
+static void bk7258_rxint(struct uart_dev_s *dev, bool enable);
+static bool bk7258_rxavailable(struct uart_dev_s *dev);
+static void bk7258_send(struct uart_dev_s *dev, int ch);
+static void bk7258_txint(struct uart_dev_s *dev, bool enable);
+static bool bk7258_txready(struct uart_dev_s *dev);
+static bool bk7258_txempty(struct uart_dev_s *dev);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct uart_ops_s g_uart_ops =
+{
+  .setup       = bk7258_setup,
+  .shutdown    = bk7258_shutdown,
+  .attach      = bk7258_attach,
+  .detach      = bk7258_detach,
+  .ioctl       = bk7258_ioctl,
+  .receive     = bk7258_receive,
+  .rxint       = bk7258_rxint,
+  .rxavailable = bk7258_rxavailable,
+  .send        = bk7258_send,
+  .txint       = bk7258_txint,
+  .txready     = bk7258_txready,
+  .txempty     = bk7258_txempty,
+};
+
+static char g_uart0rxbuffer[CONFIG_UART0_RXBUFSIZE];
+static char g_uart0txbuffer[CONFIG_UART0_TXBUFSIZE];
+
+static struct bk7258_uart_s g_uart0priv =
+{
+  .uartbase = CONSOLE_BASE,
+  .baud     = CONSOLE_BAUD,
+  .irq      = CONSOLE_IRQ,
+  .ie       = 0,
+};
+
+static struct uart_dev_s g_uart0port =
+{
+  .isconsole = true,
+  .recv      =
+  {
+    .size    = CONFIG_UART0_RXBUFSIZE,
+    .buffer  = g_uart0rxbuffer,
+  },
+  .xmit      =
+  {
+    .size    = CONFIG_UART0_TXBUFSIZE,
+    .buffer  = g_uart0txbuffer,
+  },
+  .ops       = &g_uart_ops,
+  .priv      = &g_uart0priv,
+};
+
+#define CONSOLE_DEV g_uart0port
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void bk7258_restoreint(struct bk7258_uart_s *priv)
+{
+  putreg32(priv->ie, BK7258_UART_INT_ENABLE(priv->uartbase));
+}
+
+/****************************************************************************
+ * Name: bk7258_setup
+ ****************************************************************************/
+
+static int bk7258_setup(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  uint32_t div = (BK7258_UARTCLK + (priv->baud / 2)) / priv->baud - 1;
+  uint32_t cfg;
+  uint32_t fc;
+
+  /* Do not soft reset (it would break the bootloader's working UART0 TX
+   * state).  Only set 8N1 / baud / TX+RX enable on top of the existing
+   * config, keeping the bootloader's clock/FIFO state.
+   */
+
+  cfg  = getreg32(BK7258_UART_CONFIG(priv->uartbase));
+  cfg &= ~(UART_CFG_DATA_BITS_MASK | UART_CFG_CLK_DIV_MASK);
+  cfg |= UART_CFG_DATA_BITS_8;
+  cfg |= (div << UART_CFG_CLK_DIV_SHIFT) & UART_CFG_CLK_DIV_MASK;
+  cfg |= UART_CFG_TX_ENABLE | UART_CFG_RX_ENABLE;
+  putreg32(cfg, BK7258_UART_CONFIG(priv->uartbase));
+
+  /* FIFO config: set RX threshold to 1 and enable RX stop detection so a
+   * single keystroke triggers the RX interrupt.  (Without the soft reset,
+   * fifo_config keeps the bootloader's high RX threshold, so interactive
+   * input never triggers an interrupt and received characters pile up in
+   * the RX FIFO -- SWD measured rx_fifo_count=60.)
+   * fifo_config (0x14): tx_threshold[7:0] | rx_threshold[15:8] |
+   * rx_stop_detect[17:16].
+   */
+
+  fc  = getreg32(BK7258_UART_FIFO_CFG(priv->uartbase));
+  fc &= ~((0xffu << 8) | (0x3u << 16));
+  fc |= (0x01u << 8) | (0x02u << 16);
+  putreg32(fc, BK7258_UART_FIFO_CFG(priv->uartbase));
+
+  /* All interrupts disabled for now */
+
+  priv->ie = 0;
+  bk7258_restoreint(priv);
+  return OK;
+}
+
+static void bk7258_shutdown(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  priv->ie = 0;
+  bk7258_restoreint(priv);
+}
+
+static int bk7258_attach(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  int ret = irq_attach(priv->irq, bk7258_interrupt, dev);
+  if (ret == OK)
+    {
+      up_enable_irq(priv->irq);
+    }
+
+  return ret;
+}
+
+static void bk7258_detach(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  up_disable_irq(priv->irq);
+  irq_detach(priv->irq);
+}
+
+static int bk7258_interrupt(int irq, void *context, void *arg)
+{
+  struct uart_dev_s *dev = (struct uart_dev_s *)arg;
+  struct bk7258_uart_s *priv = dev->priv;
+  uint32_t status;
+
+  status = getreg32(BK7258_UART_INT_STATUS(priv->uartbase));
+
+  /* Write 1 to clear the asserted status bits */
+
+  putreg32(status, BK7258_UART_INT_STATUS(priv->uartbase));
+
+  if (status & (UART_INT_RX_NEED_READ | UART_INT_RX_FINISH))
+    {
+      uart_recvchars(dev);
+    }
+
+  if (status & UART_INT_TX_NEED_WRITE)
+    {
+      uart_xmitchars(dev);
+    }
+
+  return OK;
+}
+
+static int bk7258_ioctl(struct file *filep, int cmd, unsigned long arg)
+{
+  UNUSED(filep);
+  UNUSED(cmd);
+  UNUSED(arg);
+  return -ENOTTY;
+}
+
+static int bk7258_receive(struct uart_dev_s *dev, unsigned int *status)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  uint32_t rbr = getreg32(BK7258_UART_FIFO_PORT(priv->uartbase));
+
+  *status = 0;
+  return (int)((rbr >> UART_FIFO_RX_DATA_SHIFT) & 0xff);
+}
+
+static void bk7258_rxint(struct uart_dev_s *dev, bool enable)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  irqstate_t flags = enter_critical_section();
+
+  if (enable)
+    {
+      priv->ie |= UART_INT_RX_NEED_READ | UART_INT_RX_FINISH;
+    }
+  else
+    {
+      priv->ie &= ~(UART_INT_RX_NEED_READ | UART_INT_RX_FINISH);
+    }
+
+  bk7258_restoreint(priv);
+  leave_critical_section(flags);
+}
+
+static bool bk7258_rxavailable(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  return (getreg32(BK7258_UART_FIFO_STATUS(priv->uartbase)) &
+          UART_FIFO_RD_READY) != 0;
+}
+
+static void bk7258_send(struct uart_dev_s *dev, int ch)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  putreg32((uint32_t)(uint8_t)ch, BK7258_UART_FIFO_PORT(priv->uartbase));
+}
+
+static void bk7258_txint(struct uart_dev_s *dev, bool enable)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  irqstate_t flags = enter_critical_section();
+
+  if (enable)
+    {
+      priv->ie |= UART_INT_TX_NEED_WRITE;
+      bk7258_restoreint(priv);
+
+      /* Fake a TX interrupt to prime the pump */
+
+      uart_xmitchars(dev);
+    }
+  else
+    {
+      priv->ie &= ~UART_INT_TX_NEED_WRITE;
+      bk7258_restoreint(priv);
+    }
+
+  leave_critical_section(flags);
+}
+
+static bool bk7258_txready(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  return (getreg32(BK7258_UART_FIFO_STATUS(priv->uartbase)) &
+          UART_FIFO_WR_READY) != 0;
+}
+
+static bool bk7258_txempty(struct uart_dev_s *dev)
+{
+  struct bk7258_uart_s *priv = dev->priv;
+  return (getreg32(BK7258_UART_FIFO_STATUS(priv->uartbase)) &
+          UART_FIFO_TX_EMPTY) != 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void arm_earlyserialinit(void)
+{
+  /* The console low level is already set up by bk7258_lowsetup(); make sure
+   * RX is enabled here as well.
+   */
+
+  CONSOLE_DEV.isconsole = true;
+  bk7258_setup(&CONSOLE_DEV);
+}
+
+void arm_serialinit(void)
+{
+  uart_register("/dev/console", &g_uart0port);
+  uart_register("/dev/ttyS0", &g_uart0port);
+}
+
+void up_putc(int ch)
+{
+  arm_lowputc((char)ch);
+}

--- a/arch/arm/src/bk7258/bk7258_start.c
+++ b/arch/arm/src/bk7258/bk7258_start.c
@@ -1,0 +1,225 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_start.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <nuttx/init.h>
+#include <arch/board/board.h>
+
+#include "arm_internal.h"
+#include "nvic.h"
+
+#include "chip.h"
+#include "hardware/bk7258_memorymap.h"
+#include "bk7258_lowputc.h"
+#include "bk7258_start.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Emit single-character start-up milestones to the console only when
+ * CONFIG_DEBUG_FEATURES is set; a no-op otherwise.  Useful for early
+ * bring-up to locate where start-up stalls.
+ */
+
+#ifdef CONFIG_DEBUG_FEATURES
+#  define showprogress(c) arm_lowputc(c)
+#else
+#  define showprogress(c)
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* g_idle_topstack: top of the idle thread stack = end of .bss (_ebss) plus
+ * the idle stack size.  The heap starts right after it (see
+ * bk7258_allocateheap.c).
+ */
+
+const uintptr_t g_idle_topstack =
+  (uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: __start
+ *
+ * Description:
+ *   Reset entry point (naked).  Entered by a jump from the bootloader --
+ *   this is a "jump", not a true reset, so like ARMINO Reset_Handler_Cpu0
+ *   it must explicitly:
+ *     1) reload SP from vector[0] (make sure the stack is correct);
+ *     2) clear MSPLIM (the Armv8-M stack-limit register; a stale value left
+ *        by the bootloader would trigger a stack-limit violation on the
+ *        first push -> UsageFault -> no output at all).
+ *   It then branches into the C start-up body bk7258_cstart().
+ *
+ ****************************************************************************/
+
+void __start(void) naked_function;
+void __start(void)
+{
+  /* Ordering is critical (verified by SWD single-step): before setting SP
+   * we must first
+   *   (1) clear MSPLIM -- the bootloader leaves a high stack-limit value
+   *       and our SP (0x28011c68) is below it; setting SP before clearing
+   *       the limit means any exception push in between hits SP < MSPLIM
+   *       -> STKOF; and
+   *   (2) enable the FPU -- an exception push does an FPU lazy save
+   *       (FPCCR.LSPEN); with the FPU off this raises NOCP.
+   * Together (measured CFSR=0x00180000: NOCP+STKOF) these cause a double
+   * fault -> LOCKUP, so clear MSPLIM and enable the FPU first, then set SP
+   * and VTOR.  (Also: never write DTCM 0x20000000; on a CPU0 cold boot it
+   * is not enabled and any access faults.)  Steps (3) set SP = vector[0]
+   * and (4) point VTOR at our vector table so early exceptions are handled
+   * by this image.
+   */
+
+  __asm__ __volatile__
+  (
+    "  cpsid i\n"                 /* Disable interrupts */
+    "  movs  r0, #0\n"
+    "  msr   MSPLIM, r0\n"        /* (1) clear the stack limit first */
+    "  ldr   r0, =0xE000ED88\n"   /* (2) enable FPU: SCB->CPACR */
+    "  ldr   r1, [r0]\n"
+    "  ldr   r2, =0x00f00000\n"   /* CP10/CP11 = full access (bits 23:20) */
+    "  orr   r1, r1, r2\n"
+    "  str   r1, [r0]\n"
+    "  dsb\n"
+    "  isb\n"
+    "  ldr   r0, =_vectors\n"     /* (3) set SP = vector[0] */
+    "  ldr   r1, [r0]\n"
+    "  mov   sp, r1\n"
+    "  ldr   r0, =_vectors\n"     /* (4) point VTOR at our vectors */
+    "  ldr   r1, =0xE000ED08\n"   /* SCB->VTOR */
+    "  str   r0, [r1]\n"
+    "  b     bk7258_cstart\n"     /* Enter the C start-up body */
+  );
+}
+
+/****************************************************************************
+ * Name: bk7258_wdt_disable
+ *
+ * Description:
+ *   Disable the AON WDT and the normal WDT.  The bootloader enables a
+ *   watchdog (~100ms); if NuttX does not disable/feed it early it will be
+ *   reset -> boot loop.  The sequence is from ARMINO wdt_hal_close()
+ *   (SOC_AON_WDT_REG_BASE=0x44000600, SOC_WDT_REG_BASE=0x44800000).
+ *
+ ****************************************************************************/
+
+static void bk7258_wdt_disable(void)
+{
+  uint32_t v;
+
+  /* AON WDT: write key (0x5A/0xA5) << 16, period = 0 */
+
+  putreg32(0x5a0000, BK7258_AON_WDT_BASE);
+  putreg32(0xa50000, BK7258_AON_WDT_BASE);
+
+  /* Normal WDT: global_ctrl (off 0x08) bit1 = 1, then ctrl (off 0x10)
+   * write key, period = 0.
+   */
+
+  v = getreg32(BK7258_WDT_BASE + 0x08);
+  putreg32(v | (1u << 1), BK7258_WDT_BASE + 0x08);
+  putreg32(0x5a0000, BK7258_WDT_BASE + 0x10);
+  putreg32(0xa50000, BK7258_WDT_BASE + 0x10);
+}
+
+/****************************************************************************
+ * Name: bk7258_cstart
+ *
+ * Description:
+ *   C start-up body: set up the console -> clear .bss -> copy .data ->
+ *   board initialization -> nx_start.
+ *
+ ****************************************************************************/
+
+void bk7258_cstart(void) noreturn_function;
+void bk7258_cstart(void)
+{
+  const uint32_t *src;
+  uint32_t *dest;
+
+  /* Initialize the console UART (UART0 = on-board CH340) */
+
+  bk7258_lowsetup();
+  showprogress('A');
+
+  /* Disable the bootloader watchdog, otherwise we get reset into a boot
+   * loop.
+   */
+
+  bk7258_wdt_disable();
+  showprogress('B');
+
+  /* Clear .bss */
+
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; dest++)
+    {
+      *dest = 0;
+    }
+
+  showprogress('C');
+
+  /* Move the initialized data from its load address (_eronly) to RAM */
+
+  for (src = (const uint32_t *)_eronly, dest = (uint32_t *)_sdata;
+       dest < (uint32_t *)_edata;
+       dest++, src++)
+    {
+      *dest = *src;
+    }
+
+  showprogress('D');
+
+#ifdef CONFIG_ARCH_FPU
+  arm_fpuconfig();
+#endif
+
+  showprogress('E');
+
+  /* Perform board-specific initialization */
+
+  arm_boardinitialize();
+  showprogress('F');
+
+  showprogress('\r');
+  showprogress('\n');
+
+  nx_start();
+
+  /* Shouldn't get here */
+
+  for (; ; )
+    {
+    }
+}

--- a/arch/arm/src/bk7258/bk7258_start.h
+++ b/arch/arm/src/bk7258/bk7258_start.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_start.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_BK7258_BK7258_START_H
+#define __ARCH_ARM_SRC_BK7258_BK7258_START_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* Reset entry point (defined in bk7258_start.c) */
+
+void __start(void);
+
+#endif /* __ARCH_ARM_SRC_BK7258_BK7258_START_H */

--- a/arch/arm/src/bk7258/bk7258_timerisr.c
+++ b/arch/arm/src/bk7258/bk7258_timerisr.c
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/bk7258_timerisr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Porting reference: arch/arm/src/mps/mps_timer.c (armv8-m SysTick). */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <arch/board/board.h>
+#include <nuttx/timers/arch_timer.h>
+
+#include "arm_internal.h"
+#include "systick.h"
+#include "nvic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SYSTICK_RELOAD ((BOARD_SYSTICK_CLOCK / CLK_TCK) - 1)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize the timer
+ *   hardware (SysTick).
+ *
+ ****************************************************************************/
+
+void up_timer_initialize(void)
+{
+  putreg32(SYSTICK_RELOAD, NVIC_SYSTICK_RELOAD);
+  up_timer_set_lowerhalf(systick_initialize(true, BOARD_SYSTICK_CLOCK, -1));
+}

--- a/arch/arm/src/bk7258/chip.h
+++ b/arch/arm/src/bk7258/chip.h
@@ -1,0 +1,43 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/chip.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_BK7258_CHIP_H
+#define __ARCH_ARM_SRC_BK7258_CHIP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/* Include the memory map and chip peripheral definitions.  The NVIC
+ * priority macros come from <arch/chip/chip.h>.
+ */
+
+#include "hardware/bk7258_memorymap.h"
+
+/* Number of external (peripheral) interrupts used by the armv8-m vector
+ * table.  BK7258_IRQ_NEXTINT is defined in arch/arm/include/bk7258/irq.h
+ * (pulled in via nuttx/irq.h).
+ */
+
+#define ARMV8M_PERIPHERAL_INTERRUPTS BK7258_IRQ_NEXTINT
+
+#endif /* __ARCH_ARM_SRC_BK7258_CHIP_H */

--- a/arch/arm/src/bk7258/hardware/bk7258_memorymap.h
+++ b/arch/arm/src/bk7258/hardware/bk7258_memorymap.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/hardware/bk7258_memorymap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Addresses from ARMINO SDK ap/include/soc/bk7258/reg_base.h.  Secure and
+ * Non-secure addresses differ by 0x10000000; the Secure view is used here
+ * (SOC_ADDR_OFFSET = 0 when CONFIG_SPE).  Single core CPU0, single
+ * security domain.
+ */
+
+#ifndef __ARCH_ARM_SRC_BK7258_HARDWARE_BK7258_MEMORYMAP_H
+#define __ARCH_ARM_SRC_BK7258_HARDWARE_BK7258_MEMORYMAP_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Memory regions ***********************************************************/
+
+#define BK7258_ITCM_BASE       0x00000000  /* Per-core private ITCM */
+#define BK7258_FLASH_BASE      0x02000000  /* Flash XIP data base, 8MB */
+#define BK7258_ROM_BASE        0x06000000  /* Boot ROM */
+#define BK7258_DTCM_BASE       0x20000000  /* Per-core private DTCM */
+#define BK7258_SRAM_BASE       0x28000000  /* Shared SRAM (SRAM0-5) */
+#define BK7258_SRAM_SIZE       0x000a0000  /* 640 KB */
+#define BK7258_PSRAM_BASE      0x60000000  /* PSRAM data window (64MB) */
+#define BK7258_QSPI0_BASE      0x64000000  /* QSPI0 data window */
+#define BK7258_QSPI1_BASE      0x68000000  /* QSPI1 data window */
+
+/* Peripheral register base addresses ***************************************/
+
+#define BK7258_AON_PMU_BASE    0x44000000  /* AON PMU */
+#define BK7258_AON_GPIO_BASE   0x44000400  /* AON GPIO */
+#define BK7258_AON_RTC_BASE    0x44000200  /* AON RTC */
+#define BK7258_AON_WDT_BASE    0x44000600  /* AON WDT */
+#define BK7258_SYS_BASE        0x44010000  /* System control */
+#define BK7258_FLASH_REG_BASE  0x44030000  /* Flash controller */
+#define BK7258_WDT_BASE        0x44800000  /* Watchdog */
+#define BK7258_TIMER0_BASE     0x44810000  /* Timer0 */
+#define BK7258_UART0_BASE      0x44820000  /* UART0 (CP core log port) */
+#define BK7258_SPI0_BASE       0x44870000  /* SPI0 */
+#define BK7258_TIMER1_BASE     0x45800000  /* Timer1 */
+#define BK7258_UART1_BASE      0x45830000  /* UART1 (AP core console) */
+#define BK7258_UART2_BASE      0x45840000  /* UART2 */
+#define BK7258_I2C0_BASE       0x45850000  /* I2C0 */
+#define BK7258_I2C1_BASE       0x45860000  /* I2C1 */
+#define BK7258_SPI1_BASE       0x45880000  /* SPI1 */
+#define BK7258_PWM_BASE        0x458a0000  /* PWM */
+#define BK7258_SLCD_BASE       0x458e0000  /* SLCD */
+#define BK7258_QSPI0_REG_BASE  0x46040000  /* QSPI0 controller */
+#define BK7258_QSPI1_REG_BASE  0x46060000  /* QSPI1 controller */
+#define BK7258_LCD_DISP_BASE   0x48060000  /* LCD display controller */
+#define BK7258_DMA2D_BASE      0x48080000  /* 2D graphics accelerator */
+
+#endif /* __ARCH_ARM_SRC_BK7258_HARDWARE_BK7258_MEMORYMAP_H */

--- a/arch/arm/src/bk7258/hardware/bk7258_uart.h
+++ b/arch/arm/src/bk7258/hardware/bk7258_uart.h
@@ -1,0 +1,117 @@
+/****************************************************************************
+ * arch/arm/src/bk7258/hardware/bk7258_uart.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Register layout from ARMINO SDK
+ * ap/middleware/soc/bk7258_ap/soc/uart_struct.h (uart_hw_t): each register
+ * is 32-bit and laid out contiguously.
+ */
+
+#ifndef __ARCH_ARM_SRC_BK7258_HARDWARE_BK7258_UART_H
+#define __ARCH_ARM_SRC_BK7258_HARDWARE_BK7258_UART_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "bk7258_memorymap.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register offsets *********************************************************/
+
+#define BK7258_UART_DEVID_OFFSET       0x0000  /* dev_id */
+#define BK7258_UART_VERSION_OFFSET     0x0004  /* dev_version */
+#define BK7258_UART_GLOBAL_CTRL_OFFSET 0x0008  /* global_ctrl */
+#define BK7258_UART_DEVSTATUS_OFFSET   0x000c  /* dev_status */
+#define BK7258_UART_CONFIG_OFFSET      0x0010  /* config */
+#define BK7258_UART_FIFO_CFG_OFFSET    0x0014  /* fifo_config */
+#define BK7258_UART_FIFO_STATUS_OFFSET 0x0018  /* fifo_status */
+#define BK7258_UART_FIFO_PORT_OFFSET   0x001c  /* fifo_port (TX/RX data) */
+#define BK7258_UART_INT_ENABLE_OFFSET  0x0020  /* int_enable */
+#define BK7258_UART_INT_STATUS_OFFSET  0x0024  /* int_status */
+#define BK7258_UART_FLOW_CFG_OFFSET    0x0028  /* flow_ctrl_config */
+#define BK7258_UART_WAKE_CFG_OFFSET    0x002c  /* wake_config */
+
+/* Register addresses (per UART instance) ***********************************/
+
+#define BK7258_UART_GLOBAL_CTRL(b)     ((b) + BK7258_UART_GLOBAL_CTRL_OFFSET)
+#define BK7258_UART_CONFIG(b)          ((b) + BK7258_UART_CONFIG_OFFSET)
+#define BK7258_UART_FIFO_CFG(b)        ((b) + BK7258_UART_FIFO_CFG_OFFSET)
+#define BK7258_UART_FIFO_STATUS(b)     ((b) + BK7258_UART_FIFO_STATUS_OFFSET)
+#define BK7258_UART_FIFO_PORT(b)       ((b) + BK7258_UART_FIFO_PORT_OFFSET)
+#define BK7258_UART_INT_ENABLE(b)      ((b) + BK7258_UART_INT_ENABLE_OFFSET)
+#define BK7258_UART_INT_STATUS(b)      ((b) + BK7258_UART_INT_STATUS_OFFSET)
+
+/* GLOBAL_CTRL (0x08) bit definitions ***************************************/
+
+#define UART_GLOBAL_SOFT_RESET         (1 << 0)  /* bit0: uart soft reset */
+#define UART_GLOBAL_CLK_GATE_BYPASS    (1 << 1)  /* bit1: bypass clock gate */
+
+/* CONFIG (0x10) bit definitions ********************************************/
+
+#define UART_CFG_TX_ENABLE             (1 << 0)  /* bit0: tx enable */
+#define UART_CFG_RX_ENABLE             (1 << 1)  /* bit1: rx enable */
+#define UART_CFG_DATA_BITS_SHIFT       3         /* bits[3:4]: data bits */
+#define UART_CFG_DATA_BITS_MASK        (0x3 << UART_CFG_DATA_BITS_SHIFT)
+#  define UART_CFG_DATA_BITS_5         (0x0 << UART_CFG_DATA_BITS_SHIFT)
+#  define UART_CFG_DATA_BITS_6         (0x1 << UART_CFG_DATA_BITS_SHIFT)
+#  define UART_CFG_DATA_BITS_7         (0x2 << UART_CFG_DATA_BITS_SHIFT)
+#  define UART_CFG_DATA_BITS_8         (0x3 << UART_CFG_DATA_BITS_SHIFT)
+#define UART_CFG_PARITY_EN             (1 << 5)  /* bit5: parity enable */
+#define UART_CFG_PARITY_ODD            (1 << 6)  /* bit6: 0=even,1=odd */
+#define UART_CFG_STOP_BITS_2           (1 << 7)  /* bit7: 0=1bit,1=2bit */
+#define UART_CFG_CLK_DIV_SHIFT         8         /* bits[8:23]: clk_div */
+#define UART_CFG_CLK_DIV_MASK          (0xffff << UART_CFG_CLK_DIV_SHIFT)
+
+/* FIFO_STATUS (0x18) bit definitions ***************************************/
+
+#define UART_FIFO_TX_COUNT_SHIFT       0         /* bits[0:7] */
+#define UART_FIFO_TX_COUNT_MASK        (0xff << 0)
+#define UART_FIFO_RX_COUNT_SHIFT       8         /* bits[8:15] */
+#define UART_FIFO_RX_COUNT_MASK        (0xff << 8)
+#define UART_FIFO_TX_FULL              (1 << 16) /* bit16 */
+#define UART_FIFO_TX_EMPTY             (1 << 17) /* bit17 */
+#define UART_FIFO_RX_FULL              (1 << 18) /* bit18 */
+#define UART_FIFO_RX_EMPTY             (1 << 19) /* bit19 */
+#define UART_FIFO_WR_READY             (1 << 20) /* bit20: can write TX FIFO */
+#define UART_FIFO_RD_READY             (1 << 21) /* bit21: RX FIFO has data */
+
+/* FIFO_PORT (0x1c): writing (v & 0xff) sends one byte; the low 8 bits of a
+ * read hold the received byte.  Ref uart_ll_write_byte():
+ * hw->fifo_port.v = data & 0xff;
+ */
+
+#define UART_FIFO_RX_DATA_SHIFT        8         /* rx_fifo_data_out [8:15] */
+#define UART_FIFO_RX_DATA_MASK         (0xff << 8)
+
+/* INT_ENABLE (0x20) / INT_STATUS (0x24) bit definitions ********************/
+
+#define UART_INT_TX_NEED_WRITE         (1 << 0)  /* bit0: TX FIFO writable */
+#define UART_INT_RX_NEED_READ          (1 << 1)  /* bit1: RX FIFO has data */
+#define UART_INT_RX_OVERFLOW           (1 << 2)  /* bit2: RX FIFO overflow */
+#define UART_INT_RX_PARITY_ERR         (1 << 3)  /* bit3 */
+#define UART_INT_RX_STOP_ERR           (1 << 4)  /* bit4 */
+#define UART_INT_TX_FINISH             (1 << 5)  /* bit5 */
+#define UART_INT_RX_FINISH             (1 << 6)  /* bit6: RX idle (stop) */
+#define UART_INT_RXD_WAKEUP            (1 << 7)  /* bit7 */
+
+#endif /* __ARCH_ARM_SRC_BK7258_HARDWARE_BK7258_UART_H */


### PR DESCRIPTION
Add Beken BK7258 SoC support to arch/arm (dual-core Armv8-M STAR-MC1).
NuttX runs as the CPU0 main core with an interactive NSH console on UART0.

Note: Please adhere to Contributing Guidelines.

## Summary

This patch adds a new ARM chip architecture for the **Beken BK7258**, a
dual-core Armv8-M STAR-MC1 (Cortex-M33 compatible, with FPU, up to 480MHz)
Wi-Fi AI-SoC.  The kernel previously had no BK7258 support; everything here
is built from scratch.

NuttX runs as the **CPU0 main core**, replacing the vendor ARMINO CP app, so
it directly owns UART0 (the on-board CH340, also the bootROM download port).
This brings up a full **bidirectional interactive NSH** console at 115200 8N1
(input, output and command execution all working).

The chip layer provides:

- `bk7258_start.c` — reset entry `__start`.  Because the bootloader *jumps*
  into the image (not a true reset), it clears `MSPLIM` and enables the FPU
  **before** setting SP/VTOR; otherwise a stack-limit + no-coprocessor double
  fault locks the core up with no output (measured CFSR=0x00180000).  Also
  disables the bootloader watchdog.
- `bk7258_lowputc.c` — low-level UART0 console (clock gate + XTAL source +
  GPIO11/10 pin mux), 115200 via clk_div=225 off the 26MHz XTAL.
- `bk7258_serial.c` — full UART0 upper-half driver (RX interrupt, TX, FIFO
  threshold so a single keystroke triggers RX).  Does **not** soft-reset
  UART0 (that would break the bootloader's working TX state).
- `bk7258_irq.c` — NVIC management plus the **BK7258 SYS-level interrupt
  aggregator** (0x44010080/84): a peripheral IRQ must be enabled there *and*
  in the NVIC to reach the CPU (this was the key to getting RX interrupts).
- `bk7258_timerisr.c` (SysTick), `bk7258_allocateheap.c`, register headers
  (`hardware/bk7258_{uart,memorymap}.h`) and `chip.h`.
- `arch/arm/Kconfig`: registers `config ARCH_CHIP_BK7258` and sources the
  chip Kconfig under its own `if ARCH_CHIP_BK7258` block.

Register bases, UART layout, memory map and the CPU0 app flash/RAM layout
were reverse-engineered from the ARMINO SDK and the factory CP app.elf, and
are documented in the source comments.

The board support package (bk7258-devkit) is submitted separately.

## Impact

- **New arch chip, opt-in**: only built when `CONFIG_ARCH_CHIP_BK7258=y`
  (`depends on EXPERIMENTAL`).  No existing board/config is affected.
- **No API change**: uses the standard NuttX arch/serial/irq interfaces.
- **Build**: no new toolchain or external dependency (prebuilt
  arm-none-eabi GCC 13).
- **Licensing**: Apache-2.0, standard NuttX headers.
- **Documentation / security / compatibility**: unchanged.

## Testing

**Build host**
- OS: Linux x86_64
- Compiler: prebuilt arm-none-eabi GCC 13.4.0
- Ninja + CMake build

**Static validation**
- `tools/checkpatch.sh -f` on all new/modified files: **no errors**.
- `cmake-format --check` on CMakeLists.txt: **pass**.
- No CJK characters in source or commit messages.

**Build**
- Clean build of `bk7258-devkit:nsh` succeeds
  (`./build.sh vendor/beken/boards/bk7258/bk7258-devkit/configs/nsh/ --cmake`).
- Output `nuttx.bin` ~179 KB.  Symbols land correctly:
  `_vectors @ 0x02010000` (flash XIP), `__start @ 0x02010140`.

**Runtime verification (on real BK7258 DevKit hardware)**
- Packed into the CPU0 app partition (Beken linear-CRC) and flashed over the
  CH340 via `bk_loader`.
- `picocom -b 115200 /dev/ttyUSB0` shows the `nsh>` prompt.
- Verified interactive commands: `help` (full command table), `uname -a`
  (`NuttX 0.0.0 ... arm bk7258-devkit`), `free`, `ps`, `date`.
- Both RX (keyboard input / echo) and TX (output) confirmed working.
