### PR TITLE
spinlock: do not use the owner counter as the cmpxchg expected value

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -256,8 +256,18 @@ static inline_function noinstrument_function bool
 spin_trylock_notrace(FAR volatile spinlock_t *lock)
 {
 #ifdef CONFIG_TICKET_SPINLOCK
-  return atomic_cmpxchg_acquire(&lock->next, &lock->owner,
-                                atomic_read(&lock->next) + 1);
+  /* The expected value must live in a local.  A failed compare-exchange
+   * writes the current value of the target object back through the
+   * expected pointer, so passing &lock->owner here would clobber the
+   * owner counter and make a lock held by another CPU appear unlocked.
+   *
+   * The exchange succeeds only when next == owner, which is the unlocked
+   * state of a ticket lock.
+   */
+
+  atomic_t expected = atomic_read(&lock->owner);
+
+  return atomic_cmpxchg_acquire(&lock->next, &expected, expected + 1);
 #else /* CONFIG_TICKET_SPINLOCK */
   return atomic_xchg_acquire(&lock->lock, 1) != 1;
 #endif /* CONFIG_TICKET_SPINLOCK */


### PR DESCRIPTION
## Summary

`spin_trylock_notrace()` passed `&lock->owner` as the *expected* argument of
`atomic_cmpxchg_acquire()`:

```c
return atomic_cmpxchg_acquire(&lock->next, &lock->owner,
                              atomic_read(&lock->next) + 1);
```

`atomic_cmpxchg_acquire()` resolves to `atomic_compare_exchange_4()`, whose
second parameter is an in/out pointer: when the comparison fails the
implementation writes the target object's current value back through it. A
failed trylock on a held lock therefore performs `lock->owner = lock->next`.

A ticket lock is held exactly when `next != owner`, so equalizing the two
counters makes a lock that is still held read back as free:

```
CPU0 holds ticket 0     owner=0 next=1   (locked)
CPU1 trylock fails      owner=1 next=1   (reads back as UNLOCKED)
```

The next `spin_trylock()` or `spin_lock()` then walks into the critical section
alongside the real holder. Worse, once both release, `owner` is incremented past
`next` (`owner=3 next=2`) and the ticket sequence stays broken for good: every
later waiter spins on a ticket that will never come up.

Keep the expected value in a local so that a failed exchange only touches that
local, and derive the desired value from the same local. This also removes a
second, independent problem in the old code: `next` was re-read in a separate
access, so `expected` and `desired` came from different points in time.

The compare-exchange is still required. The split read is safe because both
counters are monotonic and `owner <= next` always holds, so with
`expected = owner(t0)` and the exchange at `t1`:

```
expected = owner(t0) <= owner(t1) <= next(t1)
```

and success requires `next(t1) == expected`, which squeezes out
`owner(t1) == next(t1)` -- the lock really was free. The window can only cause a
spurious failure, never a false acquisition, which is acceptable for trylock.

Reported in apache/nuttx#19808.

## Impact

- Requires `CONFIG_TICKET_SPINLOCK=y`. The only in-tree config enabling it on
  this branch is `boards/sim/sim/sim/configs/smp/defconfig`.
- Triggered whenever a *held* ticket spinlock receives a `spin_trylock()` /
  `spin_trylock_notrace()` / `spin_trylock_irqsave()` call. In-tree callers are
  `boards/boardctl.c` (`BOARDIOC_SPINLOCK`, needs `CONFIG_BOARDCTL_SPINLOCK=y`)
  and `pthread_spin_trylock()`. The kernel itself never calls trylock, which is
  why default configurations do not hit this.
- Consequences depend on the protected data: memory corruption, inconsistent
  scheduler or driver state, racing hardware register access, and permanent
  deadlock on the affected lock.
- No API or ABI change. The non-ticket (`atomic_xchg_acquire`) path is
  untouched, and `rspin_lock()` / `rspin_trylock()` already keep the expected
  value in a local, so they were never affected.
- Memory ordering is unchanged (`atomic_cmpxchg_acquire`).

## Testing

Reproduced and verified on `qemu-armv7a:smp`, Cortex-A7 x4, GICv2, on a tree
carrying the same ticket-lock implementation, using an instrumented
`apps/examples/hello` that calls the kernel spinlock helpers directly
(`CONFIG_BUILD_FLAT=y`).

Before the fix:

```
[Test 1: deterministic, single thread]
  after spin_lock (we hold it)   owner=0 next=1 is_locked=true
  trylock on a HELD lock returned false (must be false)
  after the failed trylock       owner=1 next=1 is_locked=false
  >>> CORRUPTED: a lock we still hold reports UNLOCKED
  >>> spin_lock() on the same held lock returned, exclusion is gone
  after both unlock              owner=3 next=2 is_locked=true
  >>> owner ran past next, lock stuck locked forever: yes

[Test 2: two threads pinned to cpu1 / cpu2]
  B (cpu2): A holds the lock, calling spin_trylock
  B: trylock returned false
  B sees after trylock           owner=1 next=1 is_locked=false
  B (cpu2): inside the CS, A still holds it (a_holds=1)
  A (cpu1): B WAS INSIDE MY CRITICAL SECTION
  result: MUTUAL EXCLUSION BROKEN
```

After the fix:

```
[Test 1] after the failed trylock  owner=0 next=1 is_locked=true
         OK: lock state intact
         trylock on a FREE lock returned true (must be true)
[Test 2] result: exclusion held
```

Note that ARMv7-A compiles the compare-exchange to native `ldrex`/`strex`
rather than the `arch_atomic.c` software fallback, and the corruption still
occurred -- confirming the root cause is the C-level aliasing of `&lock->owner`
as the expected pointer, independent of the atomic backend.