### PR TITLE
fix(sched): correct critical monitor state

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -1528,7 +1528,9 @@ void write_unlock_irqrestore(FAR rwlock_t *lock, irqstate_t flags);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) || \
+    CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0 || \
+    defined(CONFIG_SCHED_INSTRUMENTATION_CSECTION)
 #  define enter_critical_section_notrace() rspin_lock_irqsave(&g_schedlock)
 #else
 #  define enter_critical_section_notrace() up_irq_save()
@@ -1581,7 +1583,9 @@ irqstate_t enter_critical_section(void) noinstrument_function;
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
+#if defined(CONFIG_SMP) || \
+    CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0 || \
+    defined(CONFIG_SCHED_INSTRUMENTATION_CSECTION)
 #  define leave_critical_section_notrace(f) rspin_unlock_irqrestore(&g_schedlock, f)
 #else
 #  define leave_critical_section_notrace(f) up_irq_restore(f)

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -53,6 +53,11 @@ DEFINE_PER_CPU_BMP(rspinlock_t, g_schedlock) = RSPINLOCK_INITIALIZER;
     defined(CONFIG_SCHED_INSTRUMENTATION_CSECTION)
 void restore_critical_section(uint16_t count)
 {
+  if (count == 0)
+    {
+      return;
+    }
+
   /* If CONFIG_SCHED_CRITMONITOR_MAXTIME_BUSYWAIT >= 0,
    * start counting time of busy-waiting.
    */
@@ -81,10 +86,11 @@ void restore_critical_section(uint16_t count)
 uint16_t break_critical_section(void)
 {
   FAR struct tcb_s *rtcb = running_task();
+  uint16_t count = rspin_lock_count(&g_schedlock);
 
-  /* If rtcb is NULL, it means rtcb has exited. */
+  /* Only stop a timer that was started for an actual critical section. */
 
-  if (rtcb != NULL)
+  if (rtcb != NULL && count > 0)
     {
 #  ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
       sched_note_csection(rtcb, false);

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -280,16 +280,23 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state,
       tcb->crit_start  = current;
       tcb->crit_caller = caller;
     }
-  else
+  else if (tcb->crit_caller != NULL)
     {
       /* Leaving .. Check for the max elapsed time */
 
       clock_t elapsed = current - tcb->crit_start;
+      FAR void *caller = tcb->crit_caller;
+
+      /* Clear the active marker before reporting.  Reporting can enter
+       * another critical section through the syslog backend.
+       */
+
+      tcb->crit_caller = NULL;
 
       if (elapsed > tcb->crit_max)
         {
           tcb->crit_max        = elapsed;
-          tcb->crit_max_caller = tcb->crit_caller;
+          tcb->crit_max_caller = caller;
           CHECK_CSECTION(tcb->pid, elapsed);
         }
 

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -83,6 +83,14 @@ int nxtask_exit(void)
   sinfo("%s pid=%d,TCB=%p\n", get_task_name(dtcb),
         dtcb->pid, dtcb);
 
+  /* Finish critical section accounting while this task is still current.
+   * A threshold report may use a syslog mutex owned by this task.
+   */
+
+#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
+  nxsched_critmon_csection(dtcb, false, NULL);
+#endif
+
   /* Remove the TCB of the current task from the ready-to-run list.  A
    * context switch will definitely be necessary -- that must be done
    * by the architecture-specific logic.
@@ -120,9 +128,6 @@ int nxtask_exit(void)
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_CSECTION
   sched_note_csection(dtcb, false);
-#endif
-#if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
-  nxsched_critmon_csection(dtcb, false, NULL);
 #endif
 
   sched_note_stop(dtcb);


### PR DESCRIPTION
## Summary

On uniprocessor builds, critical-section monitoring did not maintain
the scheduler lock nesting count. As a result,
`break_critical_section()` could close a timer at depth zero and
`restore_critical_section(0)` could start a new timer. Normal
scheduling intervals were then reported as critical sections.

This change:

- uses `g_schedlock` on UP when csection monitoring or
  instrumentation needs nesting state;
- ignores zero-depth restore and only settles active sections;
- clears the active caller before threshold reporting to tolerate
  syslog reentry;
- settles task-exit accounting while the exiting task is still current.

## Impact

The change only affects builds with critical-section monitoring or
csection instrumentation enabled. Other UP builds retain the direct
IRQ save/restore path. SMP behavior is unchanged.

It removes false critical-section durations and prevents recursive
threshold reporting from leaving stale state.

## Testing

Build host: Linux x86_64, RISC-V GCC toolchain.
Target: BL616CL, OpenVela NSH configuration.

- Critical monitor disabled clean build: 1204/1204.
- Critical monitor enabled clean build: 1207/1207.
- All four modified files pass `nxstyle`.
- Before the fix, `sleep 2` produced a false csection maximum of
  about 2.02 seconds.
- After the fix, the same steady-state window reported 96 us.
- A 150 ms temporary threshold produced 161-197 ms warnings without
  the previous semaphore assertion.
- Panic threshold testing reached
  `nxsched_critmon_csection -> nxtask_exit -> up_exit` as expected.
- GPIO, timer, oneshot, and watchdog regressions passed on hardware.
