### PR TITLE
fix(risc-v): preserve lazy FPU contexts

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -329,7 +329,8 @@
 #  define FPU_XCPT_SIZE     (0)
 #endif /* CONFIG_ARCH_FPU */
 
-#define XCPTCONTEXT_REGS    (INT_XCPT_REGS + FPU_XCPT_REGS)
+#define XCPTCONTEXT_REGS     (INT_XCPT_REGS + FPU_XCPT_REGS)
+#define SAVEUSERCONTEXT_SIZE (INT_XCPT_SIZE + FPU_XCPT_SIZE)
 
 #ifdef CONFIG_ARCH_LAZYFPU
 /* Save only integer regs. FPU is handled separately */
@@ -652,6 +653,10 @@ struct xcptcontext
    */
 
   uintreg_t *saved_regs;
+
+#if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARCH_LAZYFPU)
+  uintreg_t saved_fregs[FPU_XCPT_REGS];
+#endif
 
 #ifndef CONFIG_BUILD_FLAT
   /* This is the saved address to use when returning from a user-space

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -91,6 +91,12 @@ void up_schedule_sigaction(struct tcb_s *tcb)
 
   tcb->xcp.saved_regs        = tcb->xcp.regs;
 
+#if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARCH_LAZYFPU)
+  riscv_savefpu(tcb->xcp.saved_regs, tcb->xcp.fregs);
+  memcpy(tcb->xcp.saved_fregs, tcb->xcp.fregs,
+         sizeof(tcb->xcp.saved_fregs));
+#endif
+
   /* Duplicate the register context.  These will be
    * restored by the signal trampoline after the signal has been
    * delivered.

--- a/arch/risc-v/src/common/riscv_sigdeliver.c
+++ b/arch/risc-v/src/common/riscv_sigdeliver.c
@@ -115,6 +115,11 @@ retry:
 
   board_autoled_off(LED_SIGNAL);
 
+#if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARCH_LAZYFPU)
+  memcpy(rtcb->xcp.fregs, rtcb->xcp.saved_fregs,
+         sizeof(rtcb->xcp.fregs));
+#endif
+
   g_running_task = NULL;
   rtcb->xcp.regs = regs;
   riscv_fullcontextrestore();

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -94,6 +94,14 @@
  * Pre-processor definitions
  ****************************************************************************/
 
+/* Size required by up_saveusercontext().  Architectures may override this
+ * when the saved user context differs from an interrupt context.
+ */
+
+#ifndef SAVEUSERCONTEXT_SIZE
+#  define SAVEUSERCONTEXT_SIZE XCPTCONTEXT_SIZE
+#endif
+
 #define IRQ_RISING_EDGE          0x00
 #define IRQ_FALLING_EDGE         0x01
 #define IRQ_BOTH_EDGE            0x02
@@ -2986,6 +2994,9 @@ ssize_t up_show_cpuinfo(FAR char *buf, size_t buf_size, off_t file_off);
  *
  * Description:
  *   Save the current thread context
+ *
+ * Input Parameters:
+ *   saveregs - Buffer of at least SAVEUSERCONTEXT_SIZE bytes
  *
  ****************************************************************************/
 

--- a/libs/libc/gdbstub/lib_gdbstub.c
+++ b/libs/libc/gdbstub/lib_gdbstub.c
@@ -2172,7 +2172,8 @@ FAR struct gdb_state_s *gdb_state_init(gdb_send_func_t send,
   state->recv = recv;
   state->priv = priv;
   state->monitor = monitor;
-  state->running_regs = lib_memalign(XCPTCONTEXT_ALIGN, XCPTCONTEXT_SIZE);
+  state->running_regs = lib_memalign(XCPTCONTEXT_ALIGN,
+                                     SAVEUSERCONTEXT_SIZE);
 
 #ifdef CONFIG_LIB_GDBSTUB_DEBUG
   lib_syslograwstream_open(&state->stream);

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -84,7 +84,7 @@ struct elf_dumpinfo_s
  * Private Data
  ****************************************************************************/
 
-static uint8_t g_running_regs[XCPTCONTEXT_SIZE]
+static uint8_t g_running_regs[SAVEUSERCONTEXT_SIZE]
                aligned_data(XCPTCONTEXT_ALIGN);
 
 #ifdef CONFIG_BOARD_COREDUMP_COMPRESSION


### PR DESCRIPTION
## Summary

- define the storage contract required by `up_saveusercontext()`
- size coredump and gdbstub buffers for the full saved user context
- snapshot lazy FPU registers across asynchronous signal delivery

## Root cause

With `CONFIG_ARCH_LAZYFPU`, `XCPTCONTEXT_SIZE` contains only the integer
interrupt frame, while RISC-V `up_saveusercontext()` still appends all FPRs
and FCSR. Coredump and gdbstub allocated only `XCPTCONTEXT_SIZE`, causing a
132-byte overwrite on RV32F.

Signal delivery also reused the sole per-thread lazy FPU save area. A handler
using floating point followed by a context switch could replace the
interrupted thread FPRs and FCSR before signal return.

## Fix

- add `SAVEUSERCONTEXT_SIZE`, defaulting to `XCPTCONTEXT_SIZE`
- override it on RISC-V with integer plus FPU save sizes
- add a dedicated lazy-FPU signal snapshot and restore it before returning

## Prior implementation

OpenVela `rel-4.0` commit `fcbf6423f2a` saves a running task's live FPU
context before constructing a signal context. This PR preserves that
live-save behavior for lazy FPU and extends it with a second `saved_fregs`
snapshot, because a handler that uses FPU and then blocks or is preempted can
overwrite the sole runtime `fregs` area.

The `rel-4.0` patch cannot be cherry-picked directly because the trunk signal
API and context layout differ.

## Verification

- NuttX `tools/checkpatch.sh`: pass
- BL616CL RV32F lazy-FPU clean build: 1222/1222
- asynchronous signal test covers 32 FPRs, FCSR, handler FPU use, context
  switches, and timer IRQ activity
- final product clean build: 1219/1219
- USB2 GPIO, timer, oneshot, watchdog, and final-alive regression: pass

Jira: VELABL616-150
