### PR TITLE
fix(rtc): validate initialize inputs

### DIFF
--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -824,7 +824,10 @@ int rtc_initialize(int minor, FAR struct rtc_lowerhalf_s *lower)
   char devpath[20];
   int ret;
 
-  DEBUGASSERT(lower && lower->ops && minor >= 0 && minor < 1000);
+  if (lower == NULL || lower->ops == NULL || minor < 0 || minor >= 1000)
+    {
+      return -EINVAL;
+    }
 
   /* Allocate an upper half container structure */
 


### PR DESCRIPTION
## Summary

- Validate `rtc_initialize()` lower, ops, and minor before allocation.
- Preserve register failure cleanup and lower-half ownership.
- Return deterministic `-EINVAL` in release builds.

## Verification

- `tools/nxstyle drivers/timers/rtc.c`
- `git diff | tools/checkpatch.sh -`
- BL616CL RV32 debug/release: 37/37 initialize cases pass.
- LP64 integrated sim: initialize 37/37 and ioctl all 41/41 pass.

VELABL616-156
