### PR TITLE
mm: preserve stack record on failed realloc

### DIFF
--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -78,6 +78,9 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   size_t nextsize = 0;
   FAR void *newmem;
   bool bypass;
+#ifdef CONFIG_MM_RECORD_STACK
+  FAR void *oldstack;
+#endif
 
   /* If oldmem is NULL, then realloc is equivalent to malloc */
 
@@ -144,8 +147,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   DEBUGASSERT(MM_NODE_IS_ALLOC(oldnode));
 
 #ifdef CONFIG_MM_RECORD_STACK
-  backtrace_remove(oldnode->stack);
-  oldnode->stack = NULL;
+  oldstack = oldnode->stack;
 #endif
 
   /* Check if this is a request to reduce the size of the allocation. */
@@ -168,6 +170,10 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
       /* Then return the original address */
 
+#ifdef CONFIG_MM_RECORD_STACK
+      backtrace_remove(oldstack);
+      oldnode->stack = NULL;
+#endif
       kasan_bypass(bypass);
       DEBUGVERIFY(nxrmutex_unlock(&heap->mm_lock));
       MM_RECORD(heap, oldnode);
@@ -399,6 +405,10 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
       sched_note_heap(NOTE_HEAP_ALLOC, heap, newmem, newsize,
                       heap->mm_curused);
 
+#ifdef CONFIG_MM_RECORD_STACK
+      backtrace_remove(oldstack);
+      oldnode->stack = NULL;
+#endif
       size = MM_SIZEOF_NODE(oldnode);
 
       kasan_bypass(bypass);


### PR DESCRIPTION
## Summary

Delay MM_RECORD_STACK removal until an in-place realloc succeeds. A fallback allocation failure now leaves the original allocation node and diagnostic stack record untouched.

## Evidence

- BL616CL USB2 red baseline: R05 returned NULL and changed stack from a valid entry/depth 3 to NULL/depth 0.
- Fixed BL616CL USB2: R01-R06 pass; R06 duplicate stack refcount observed 3 -> 2 -> 1 -> 0.
- checkpatch, nxstyle, and diff check pass.
- Commit is signed off and based on openvela/trunk e987a81c32c.

VELABL616-163