### PR TITLE
net: avoid temporary allocation in procfs device lookup

### DIFF
--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -29,19 +29,18 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <net/if.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
 #include <fcntl.h>
 #include <fnmatch.h>
-#include <libgen.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
 
 #include <sys/param.h>
 
-#include <nuttx/lib/lib.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/procfs.h>
@@ -94,6 +93,8 @@ static int     netprocfs_readdir(FAR struct fs_dirent_s *dir,
 static int     netprocfs_rewinddir(FAR struct fs_dirent_s *dir);
 
 static int     netprocfs_stat(FAR const char *relpath, FAR struct stat *buf);
+static FAR const char *netprocfs_devname(FAR const char *relpath,
+                                         FAR char *buffer, size_t buflen);
 
 /****************************************************************************
  * Private Data
@@ -228,23 +229,20 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
 
   if (i == nitems(g_net_entries) - 1)
     {
-      FAR char *devname;
-      FAR char *copy;
+      char devname[IFNAMSIZ];
+      FAR const char *name;
 
       /* Otherwise, we need to search the list of registered network devices
        * to determine if the name corresponds to a network device.
        */
 
-      copy = strdup(relpath);
-      if (copy == NULL)
+      name = netprocfs_devname(relpath, devname, sizeof(devname));
+      if (name == NULL)
         {
-          ferr("ERROR: strdup failed\n");
-          return -ENOMEM;
+          return -ENOENT;
         }
 
-      devname = basename(copy);
-      dev     = netdev_findbyname(devname);
-      lib_free(copy);
+      dev = netdev_findbyname(name);
 
       if (dev == NULL)
         {
@@ -274,6 +272,40 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
 
   filep->f_priv = (FAR void *)priv;
   return OK;
+}
+
+/****************************************************************************
+ * Name: netprocfs_devname
+ ****************************************************************************/
+
+static FAR const char *netprocfs_devname(FAR const char *relpath,
+                                         FAR char *buffer, size_t buflen)
+{
+  FAR const char *start;
+  FAR const char *end;
+  size_t length;
+
+  end = relpath + strlen(relpath);
+  while (end > relpath && end[-1] == '/')
+    {
+      end--;
+    }
+
+  start = end;
+  while (start > relpath && start[-1] != '/')
+    {
+      start--;
+    }
+
+  length = end - start;
+  if (length == 0 || length >= buflen)
+    {
+      return NULL;
+    }
+
+  memcpy(buffer, start, length);
+  buffer[length] = '\0';
+  return buffer;
 }
 
 /****************************************************************************
@@ -614,23 +646,20 @@ static int netprocfs_stat(FAR const char *relpath, FAR struct stat *buf)
   if (buf->st_mode == 0)
     {
       FAR struct net_driver_s *dev;
-      FAR char *devname;
-      FAR char *copy;
+      char devname[IFNAMSIZ];
+      FAR const char *name;
 
       /* Otherwise, we need to search the list of registered network devices
        * to determine if the name corresponds to a network device.
        */
 
-      copy = strdup(relpath);
-      if (copy == NULL)
+      name = netprocfs_devname(relpath, devname, sizeof(devname));
+      if (name == NULL)
         {
-          ferr("ERROR: strdup failed\n");
-          return -ENOMEM;
+          return -ENOENT;
         }
 
-      devname = basename(copy);
-      dev     = netdev_findbyname(devname);
-      lib_free(copy);
+      dev = netdev_findbyname(name);
 
       if (dev == NULL)
         {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

