### PR TITLE
net/usrsock: Guard declarations when disabled

### DIFF
--- a/include/nuttx/net/usrsock.h
+++ b/include/nuttx/net/usrsock.h
@@ -275,6 +275,7 @@ begin_packed_struct struct usrsock_message_socket_event_s
 
 /* Global protection lock for usrsock socket */
 
+#ifdef CONFIG_NET_USRSOCK
 DECLARE_PER_CPU_BMP(rmutex_t, g_usrsock_lock);
 #define g_usrsock_lock this_cpu_var_bmp(g_usrsock_lock)
 
@@ -427,5 +428,7 @@ int usrsock_request(FAR struct iovec *iov, unsigned int iovcnt);
  ****************************************************************************/
 
 void usrsock_register(void);
+
+#endif /* CONFIG_NET_USRSOCK */
 
 #endif /* __INCLUDE_NUTTX_NET_USRSOCK_H */


### PR DESCRIPTION
## Summary

Guard the usrsock global lock and API declarations with `CONFIG_NET_USRSOCK`.

These declarations were previously exposed even when usersock support was disabled. This could cause configurations that include `nuttx/net/usrsock.h` to reference unavailable usersock definitions.

## Features

- Wrap `g_usrsock_lock` and usersock API declarations with `CONFIG_NET_USRSOCK`.
- Keep the usersock message structures available as before.
- Do not change behavior when `CONFIG_NET_USRSOCK` is enabled.

## Files

| File | Description |
|------|-------------|
| `include/nuttx/net/usrsock.h` | Guard usersock-only lock and API declarations when usersock is disabled. |

## Testing

- Applied cleanly on `open-vela/nuttx:dev-ai-contest-2026`.
- Passed NuttX `checkpatch.sh`.
- Built `contest2026_284_board:nsh` successfully.
- Built `contest2026_284_board:velapoka` successfully.